### PR TITLE
Remove signal termination for windows compatibility

### DIFF
--- a/autode/mol_graphs.py
+++ b/autode/mol_graphs.py
@@ -407,7 +407,7 @@ def get_graphs_ignoring_active_edges(graph1, graph2):
     return g1, g2
 
 
-@timeout(seconds=5)
+@timeout(seconds=5, return_value=False)
 def is_isomorphic(graph1, graph2, ignore_active_bonds=False):
     """Check whether two NX graphs are isomorphic. Contains a timeout because
     the gm.is_isomorphic() method occasionally gets stuck
@@ -443,13 +443,7 @@ def is_isomorphic(graph1, graph2, ignore_active_bonds=False):
                                       node_match=node_match,
                                       edge_match=edge_match)
 
-    # NX can hang here for not very large graphs, so kill after a timeout
-    try:
-        return gm.is_isomorphic()
-
-    except TimeoutError:
-        logger.error('NX graph matching hanging')
-        return False
+    return gm.is_isomorphic()
 
 
 def gm_is_isomorphic(gm, result):

--- a/autode/utils.py
+++ b/autode/utils.py
@@ -229,12 +229,15 @@ def requires_output():
     return func_decorator
 
 
-def timeout(seconds):
+def timeout(seconds, return_value=None):
     """
     Function dectorator that times-out after a number of seconds
 
     Arguments:
         seconds (float):
+
+    Keyword Arguments:
+        return_value (Any): Value returned if the function times out
 
     Returns:
         (Any): Result of the function
@@ -256,7 +259,7 @@ def timeout(seconds):
             if p.is_alive():
                 p.terminate()
                 p.join()
-                raise TimeoutError
+                return return_value
 
             else:
                 return q.get()

--- a/autode/utils.py
+++ b/autode/utils.py
@@ -240,10 +240,7 @@ def timeout(seconds, return_value=None):
         return_value (Any): Value returned if the function times out
 
     Returns:
-        (Any): Result of the function
-
-    Raises:
-        (TimeoutError): If current time > seconds
+        (Any): Result of the function | return_value
     """
     def handler(queue, func, args, kwargs):
         queue.put(func(*args, **kwargs))

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -269,7 +269,7 @@ def test_timeout():
 
     # With a short timeout this should return False - not sure this is the
     # optimal behavior
-    assert not mol_graphs.is_isomorphic(graph, isomorphic_graph, timeout=1)
+    assert not mol_graphs.is_isomorphic(graph, isomorphic_graph)
 
 
 def test_species_conformers_isomorphic():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -149,9 +149,7 @@ def test_timeout():
 
     # Decorated function should timeout and return in under two seconds
     start_time = time.time()
-    with pytest.raises(TimeoutError):
-        sleep_2s()
-
+    sleep_2s()
     assert time.time() - start_time < 2
 
     @utils.timeout(seconds=10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from autode.wrappers.MOPAC import MOPAC
 from autode.wrappers.keywords import Keywords
 from autode.exceptions import NoCalculationOutput
 from autode.exceptions import NoConformers
+import time
 import pytest
 import os
 
@@ -131,3 +132,33 @@ def test_work_in_empty():
     # Remove the created files and directory
     os.remove('tmp_dir/tmp.txt')
     os.rmdir('tmp_dir')
+
+
+def test_timeout():
+
+    def sleep_2s():
+        return time.sleep(2)
+
+    start_time = time.time()
+    sleep_2s()
+    assert time.time() - start_time > 2
+
+    @utils.timeout(seconds=1)
+    def sleep_2s():
+        return time.sleep(2)
+
+    # Decorated function should timeout and return in under two seconds
+    start_time = time.time()
+    with pytest.raises(TimeoutError):
+        sleep_2s()
+
+    assert time.time() - start_time < 2
+
+    @utils.timeout(seconds=10)
+    def return_string():
+        return 'test'
+
+    # Should not raise a TimeoutError if the function executes fast
+    start_time = time.time()
+    assert return_string() == 'test'
+    assert time.time() - start_time < 10


### PR DESCRIPTION
signal.SIGALRM is not present on Windows, so switch to a decorator using multiprocessing instead. **Should** improve Windows compatibility 