### PR TITLE
Linear atoms in metallocycles

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behaviour: code with output -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Environment**
+<!-- please complete the following information. -->
+ - OS:
+ - Version:
+
+**Additional context**
+<!-- Add any other context about the problem here. -->

--- a/autode/smiles/angles.py
+++ b/autode/smiles/angles.py
@@ -1,7 +1,8 @@
 import numpy as np
 import networkx as nx
 from autode.log import logger
-from autode.exceptions import (FailedToSetRotationIdxs)
+from autode.exceptions import (FailedToSetRotationIdxs,
+                               SMILESBuildFailed)
 
 
 class Angle:
@@ -208,6 +209,9 @@ class Dihedral(Angle):
 
         Returns:
             (float): The dihedral angle in radians
+
+        Raises:
+            (SMILESBuildFailed):
         """
         idx_x, idx_y, idx_z, idx_w = self.idxs
 
@@ -220,7 +224,8 @@ class Dihedral(Angle):
 
         zero_vec = np.zeros(3)
         if np.allclose(vec1, zero_vec) or np.allclose(vec2, zero_vec):
-            raise ValueError('Cannot calculate a dihedral - one zero vector')
+            raise SMILESBuildFailed('Cannot calculate a dihedral '
+                                    '- one zero vector')
 
         # Normalise everything
         vec1 /= np.linalg.norm(vec1)

--- a/autode/smiles/atom_types.py
+++ b/autode/smiles/atom_types.py
@@ -172,9 +172,13 @@ class LinearAtom(AtomType):
         Linear atom with sites pointing along the x-axis::
 
                     <---Atom--->
+
+        WARNING: Completely linear cause failures for internal coordinate
+                 optimisation algorithms and have undefined cross products.
+                 Site coordinates are therefore not precisely linear
         """
         site_coords = [np.array([1.0, 0.0, 0.0]),
-                       np.array([-1.0, 0.0, 0.0])]
+                       np.array([-1.0, 0.001, 0.0])]
 
         super().__init__(site_coords)
 

--- a/autode/smiles/builder.py
+++ b/autode/smiles/builder.py
@@ -39,6 +39,11 @@ class Builder(AtomCollection):
         return atoms
 
     @property
+    def canonical_atoms_at_origin(self):
+        """Canonical set of autodE atoms all located at the origin"""
+        return [Atom(atom.label) for atom in self.atoms]
+
+    @property
     def built_atom_idxs(self):
         """Atom indexes that have been built"""
         return [i for i in range(self.n_atoms) if self.atoms[i].is_shifted]

--- a/autode/smiles/builder.py
+++ b/autode/smiles/builder.py
@@ -1,6 +1,6 @@
 import numpy as np
 import networkx as nx
-import autode.smiles.atom_types as atom_types
+from autode.smiles import atom_types
 from autode.log import logger
 from autode.utils import log_time
 from autode.atoms import Atom, AtomCollection

--- a/autode/smiles/smiles.py
+++ b/autode/smiles/smiles.py
@@ -3,7 +3,7 @@ from rdkit.Chem.Descriptors import NumRadicalElectrons
 from rdkit import Chem
 from autode.conformers.conf_gen import get_simanl_atoms
 from autode.conformers.conformers import atoms_from_rdkit_mol
-from autode.exceptions import RDKitFailed
+from autode.exceptions import RDKitFailed, SMILESBuildFailed
 from autode.geom import are_coords_reasonable
 from autode.log import logger
 from autode.mol_graphs import make_graph
@@ -112,30 +112,29 @@ def init_organic_smiles(molecule, smiles):
 def init_smiles(molecule, smiles):
     """
     Initialise a molecule from a SMILES string
+
     Arguments:
         molecule (autode.molecule.Molecule):
         smiles (str): SMILES string
     """
-    # Assume that the RDKit conformer generation algorithm is not okay for
-    # metals
     molecule.rdkit_conf_gen_is_fine = False
-
-    if '.' in smiles:
-        raise ValueError('Could not parse SMILES with non-bonded components')
 
     parser, builder = Parser(),  Builder()
 
     parser.parse(smiles)
-    builder.build(atoms=parser.atoms, bonds=parser.bonds)
-
     molecule.charge = parser.charge
     molecule.mult = parser.mult
-    molecule.atoms = builder.canonical_atoms
+
+    try:
+        builder.build(atoms=parser.atoms, bonds=parser.bonds)
+        molecule.atoms = builder.canonical_atoms
+
+    except SMILESBuildFailed:
+        molecule.atoms = builder.canonical_atoms_at_origin
 
     make_graph(molecule, bond_list=parser.bonds)
 
     for idx, atom in enumerate(builder.atoms):
-
         if atom.has_stereochem:
             molecule.graph.nodes[idx]['stereo'] = True
 
@@ -144,7 +143,7 @@ def init_smiles(molecule, smiles):
 
     if not are_coords_reasonable(molecule.coordinates):
         logger.warning('3D builder did not make a sensible geometry, '
-                       'minimising whole structure.')
+                       'Falling back to random minimisation.')
         molecule.atoms = get_simanl_atoms(molecule, save_xyz=False)
 
     check_bonds(molecule, bonds=parser.bonds)

--- a/autode/smiles/smiles.py
+++ b/autode/smiles/smiles.py
@@ -129,7 +129,7 @@ def init_smiles(molecule, smiles):
         builder.build(atoms=parser.atoms, bonds=parser.bonds)
         molecule.atoms = builder.canonical_atoms
 
-    except SMILESBuildFailed:
+    except (SMILESBuildFailed, NotImplementedError):
         molecule.atoms = builder.canonical_atoms_at_origin
 
     make_graph(molecule, bond_list=parser.bonds)

--- a/autode/utils.py
+++ b/autode/utils.py
@@ -12,6 +12,9 @@ from autode.exceptions import (NoAtomsInMolecule,
                                NoConformers,
                                NoMolecularGraph)
 
+# Needed for additional pickle-ability
+multiprocessing.set_start_method("fork")
+
 
 def run_external(params, output_filename):
     """

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -107,6 +107,9 @@ def test_atom():
     assert dummy.period == 0
     assert dummy.group == 0
 
+    fe = Atom(atomic_symbol='Fe')
+    assert fe.tm_row == 1
+
 
 def test_periodic_table():
 

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -96,7 +96,7 @@ def test_gen_conformers():
         mol._generate_conformers()
 
     # Metal complexes must be completely bonded entities
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         _ = Molecule(smiles='[Pd]C.C')
 
 

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -109,6 +109,10 @@ def test_siman_conf_gen(tmpdir):
     assert rh_complex.n_atoms == 14
     assert 12 < rh_complex.graph.number_of_edges() < 15  # What is a bond even
 
+    # Should be able to generate even crazy molecules
+    mol = Molecule(smiles='C[Fe](C)(C)(C)(C)(C)(C)(C)C')
+    assert mol.atoms is not None
+
     os.chdir(here)
 
 

--- a/tests/test_smiles_builder.py
+++ b/tests/test_smiles_builder.py
@@ -140,7 +140,7 @@ def test_dihedrals():
             Atom('C', 2.61201, -1.79454, 0.87465)]
 
     # Can't have a dihedral with vectors of zero length
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         _ = dihedral.value(zero)
 
 

--- a/tests/test_smiles_builder.py
+++ b/tests/test_smiles_builder.py
@@ -58,6 +58,9 @@ def test_base_builder():
         assert isinstance(atom, Atom)
         assert hasattr(atom, 'coord')
 
+    for atom in builder.canonical_atoms_at_origin:
+        assert np.isclose(np.linalg.norm(atom.coord), 0.0, atol=1E-4)
+
 
 def test_build_single_atom():
     """No building needed for a single atom, but the builder should be fine"""
@@ -67,6 +70,14 @@ def test_build_single_atom():
 
     assert builder.n_atoms == 1
     assert parser.mult == 2
+
+
+def test_too_high_valance():
+
+    parser.parse(smiles='CC(C)(C)(C)(C)(C)(C)(C)(C)C')
+
+    with pytest.raises(Exception):
+        builder.build(atoms=parser.atoms, bonds=parser.bonds)
 
 
 def test_explicit_hs():

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -87,6 +87,12 @@ def test_species_translate():
     assert np.linalg.norm(mol_copy.atoms[0].coord - np.array([0.0, 0.0, -1.0])) < 1E-9
     assert np.linalg.norm(mol_copy.atoms[1].coord - np.array([0.0, 0.0, 0.0])) < 1E-9
 
+    # Centering should move the middle of the molecule to the origin
+    mol_copy.centre()
+    assert np.allclose(np.average(mol_copy.coordinates, axis=0),
+                       np.zeros(3),
+                       atol=1E-4)
+
 
 def test_species_rotate():
     mol_copy = deepcopy(mol)


### PR DESCRIPTION
Add an issue template
Fixes bug in SMILES builder where linear atoms within rings raised a ValueError
Adds fallback to previous minimisation build if builder fails