### PR TITLE
Hotfix

### DIFF
--- a/autode/smiles/parser.py
+++ b/autode/smiles/parser.py
@@ -254,8 +254,8 @@ class Parser:
                           'P': (3, 5), 'S': (2, 4, 6), 'F': (1,), 'Cl': (1,),
                           'Br': (1,), 'I': (1,),
                           # Aromatic atoms are distinct
-                          'b': (3,), 'c': (3,), 'n': (2,), 'o': (1,),
-                          'p': (3,), 's': (2,), 'se': (2,), 'as': (3,)}
+                          'b': (2,), 'c': (3,), 'n': (2,), 'o': (1,),
+                          'p': (2,), 's': (1,), 'se': (1,), 'as': (2,)}
 
         for idx, atom in enumerate(self.atoms):
 

--- a/autode/smiles/parser.py
+++ b/autode/smiles/parser.py
@@ -254,7 +254,7 @@ class Parser:
                           'P': (3, 5), 'S': (2, 4, 6), 'F': (1,), 'Cl': (1,),
                           'Br': (1,), 'I': (1,),
                           # Aromatic atoms are distinct
-                          'b': (3,), 'c': (3,), 'n': (3,), 'o': (2,),
+                          'b': (3,), 'c': (3,), 'n': (2,), 'o': (1,),
                           'p': (3,), 's': (2,), 'se': (2,), 'as': (3,)}
 
         for idx, atom in enumerate(self.atoms):

--- a/autode/smiles/smiles.py
+++ b/autode/smiles/smiles.py
@@ -166,6 +166,6 @@ def check_bonds(molecule, bonds):
     make_graph(check_molecule)
 
     if len(bonds) != check_molecule.graph.number_of_edges():
-        logger.warning('Bonds and graph do no match')
+        logger.warning('Bonds and graph do not match')
 
     return None

--- a/autode/species/molecule.py
+++ b/autode/species/molecule.py
@@ -1,3 +1,4 @@
+import re
 import rdkit
 from multiprocessing import Pool
 from rdkit.Chem import AllChem
@@ -20,9 +21,14 @@ class Molecule(Species):
 
     def _init_smiles(self, smiles):
         """Initialise a molecule from a SMILES string using RDKit if it's
-        purely organic"""
+        purely organic.
 
-        if any(f'[{metal}]' in smiles for metal in metals):
+        Arguments:
+            smiles (str):
+        """
+        at_strings = re.findall(r'\[.*?]', smiles)
+
+        if any(metal in string for metal in metals for string in at_strings):
             init_smiles(self, smiles)
 
         else:

--- a/autode/species/molecule.py
+++ b/autode/species/molecule.py
@@ -22,7 +22,7 @@ class Molecule(Species):
         """Initialise a molecule from a SMILES string using RDKit if it's
         purely organic"""
 
-        if any(metal in smiles for metal in metals):
+        if any(f'[{metal}]' in smiles for metal in metals):
             init_smiles(self, smiles)
 
         else:

--- a/tests/test_smiles_builder.py
+++ b/tests/test_smiles_builder.py
@@ -570,6 +570,21 @@ def test_double_bond_stereo_branch():
 
 def test_fused_ring_system():
     """Multiply fused rings should be buildable - repulsion needed"""
-    
+
     assert built_molecule_is_reasonable(smiles='[SiH3]C12[C@@]3(CCC4)C4=C'
                                                '[C@@H](C1C=CC2)C3')
+
+
+def test_build_exceptions():
+
+    builder.set_atoms_bonds(atoms=[SMILESAtom('H')], bonds=SMILESBonds())
+
+    # Cannot find a ring with no atoms
+    with pytest.raises(SMILESBuildFailed):
+        builder._ring_idxs(inc_idxs=(0, 1))
+
+    # Cannot find a ring path with no rings
+    bond = RingBond(1, symbol='-')
+    bond.close(1, symbol='-')
+    with pytest.raises(SMILESBuildFailed):
+        builder._ring_path(ring_bond=bond)

--- a/tests/test_smiles_builder.py
+++ b/tests/test_smiles_builder.py
@@ -3,7 +3,7 @@ import numpy as np
 from autode import Molecule
 from autode.atoms import Atom
 from autode.geom import are_coords_reasonable, calc_heavy_atom_rmsd
-from autode.smiles.parser import Parser, SMILESBonds, RingBond
+from autode.smiles.parser import Parser, SMILESBonds, RingBond, SMILESAtom
 from autode.smiles.builder import Builder, Angle, Dihedral
 from autode.exceptions import SMILESBuildFailed
 from autode.mol_graphs import get_mapping

--- a/tests/test_smiles_parser.py
+++ b/tests/test_smiles_parser.py
@@ -408,3 +408,12 @@ def test_multiplicity_metals():
 
     parser.parse(smiles='[Na]C1=CC=CC=C1')
     assert parser.mult == 1
+
+
+def test_aromatic_triazole():
+
+    parser = Parser()
+    parser.parse(smiles='[nH]1cnnc1')
+
+    # Should have 1 atom per carbon, plus one for the defined aromatic N
+    assert sum(atom.n_hydrogens for atom in parser.atoms) == 3

--- a/tests/test_smiles_parser.py
+++ b/tests/test_smiles_parser.py
@@ -1,4 +1,6 @@
+import re
 import pytest
+from autode.atoms import metals
 from autode.exceptions import InvalidSmilesString
 from autode.smiles.base import SMILESStereoChem
 from autode.smiles.parser import Parser
@@ -410,10 +412,26 @@ def test_multiplicity_metals():
     assert parser.mult == 1
 
 
-def test_aromatic_triazole():
+def test_aromatic_heteroatoms():
 
     parser = Parser()
     parser.parse(smiles='[nH]1cnnc1')
 
     # Should have 1 atom per carbon, plus one for the defined aromatic N
     assert sum(atom.n_hydrogens for atom in parser.atoms) == 3
+
+    # also should not have any Hs for aromatic B
+    parser.parse(smiles='c1c[cH-]bc1')
+    assert sum(atom.n_hydrogens for atom in parser.atoms) == 4
+
+
+def test_metal_in_smiles():
+
+    def metal_in_smiles(smiles):
+        at_strings = re.findall(r'\[.*?]', smiles)
+        return any(metal in string for metal in metals for string in at_strings)
+
+    assert not metal_in_smiles(smiles='CnnC')
+    assert metal_in_smiles(smiles='CC[W]')
+    assert metal_in_smiles(smiles='C[Pd]')
+    assert metal_in_smiles(smiles='[Fe3+]CNO[W]')


### PR DESCRIPTION
- Aromatic hetereoatoms now have the correct default vacancy
- Search for bracketed metal atoms in a SMILES string to prevent Cn being considered as a metal, when it's a carbon followed by an aromatic nitrogen
- Added test for aromatic triazole