### PR TITLE
Improved stochastic sampling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ tests/data/__MACOSX/
 tests/data/conformers/.autode_calculations
 
 autode/ext/*.cpp
+
+autode/ext/cmake-build-debug/

--- a/autode/ext/CMakeLists.txt
+++ b/autode/ext/CMakeLists.txt
@@ -16,6 +16,8 @@ add_library(autode STATIC
 find_package(Catch2 REQUIRED)
 add_executable(test
                tests/test_main.cpp
-               tests/test_point_gen.cpp)
+               tests/test_point_gen.cpp
+               tests/test_global_dihedral_min.cpp)
+
 target_link_libraries(test PRIVATE Catch2::Catch2)
 target_link_libraries(test PUBLIC autode)

--- a/autode/ext/CMakeLists.txt
+++ b/autode/ext/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.19)
+project(ade_ext)
+
+set(CMAKE_CXX_STANDARD 11)
+include_directories(include/)
+
+add_executable(ade_ext ade_ext.cpp
+               include/dihedrals.h src/dihedrals.cpp
+               include/molecule.h src/molecule.cpp
+               include/optimisers.h src/optimisers.cpp
+               include/points.h src/points.cpp
+               include/potentials.h src/potentials.cpp
+               include/utils.h src/utils.cpp
+               )

--- a/autode/ext/CMakeLists.txt
+++ b/autode/ext/CMakeLists.txt
@@ -14,8 +14,8 @@ add_library(autode STATIC
             )
 
 find_package(Catch2 REQUIRED)
-add_executable(tests
+add_executable(test
                tests/test_main.cpp
                tests/test_point_gen.cpp)
-target_link_libraries(tests PRIVATE Catch2::Catch2)
-target_link_libraries(tests PUBLIC autode)
+target_link_libraries(test PRIVATE Catch2::Catch2)
+target_link_libraries(test PUBLIC autode)

--- a/autode/ext/CMakeLists.txt
+++ b/autode/ext/CMakeLists.txt
@@ -1,14 +1,21 @@
-cmake_minimum_required(VERSION 3.19)
+cmake_minimum_required(VERSION 3.16)
 project(ade_ext)
 
 set(CMAKE_CXX_STANDARD 11)
 include_directories(include/)
 
-add_executable(ade_ext ade_ext.cpp
-               include/dihedrals.h src/dihedrals.cpp
-               include/molecule.h src/molecule.cpp
-               include/optimisers.h src/optimisers.cpp
-               include/points.h src/points.cpp
-               include/potentials.h src/potentials.cpp
-               include/utils.h src/utils.cpp
-               )
+add_library(autode STATIC
+            include/dihedrals.h src/dihedrals.cpp
+            include/molecule.h src/molecule.cpp
+            include/optimisers.h src/optimisers.cpp
+            include/points.h src/points.cpp
+            include/potentials.h src/potentials.cpp
+            include/utils.h src/utils.cpp
+            )
+
+find_package(Catch2 REQUIRED)
+add_executable(tests
+               tests/test_main.cpp
+               tests/test_point_gen.cpp)
+target_link_libraries(tests PRIVATE Catch2::Catch2)
+target_link_libraries(tests PUBLIC autode)

--- a/autode/ext/README.md
+++ b/autode/ext/README.md
@@ -1,0 +1,14 @@
+## autodE C++ extensions
+
+Some **autodE** functionality is written in C++ for speed
+and the functionality exposed to Python using Cython wrappers around
+the base classes. 
+
+Currently it's written in C++11 for compatibility with older compilers. Build and
+run the tests by, in this directory:
+
+```bash
+cmake . && make -j2 && ./test
+```
+
+*assuming 2 cores are available*.

--- a/autode/ext/ade_dihedrals.pyx
+++ b/autode/ext/ade_dihedrals.pyx
@@ -1,5 +1,5 @@
 # distutils: language = c++
-# distutils: sources = [autode/ext/src/dihedrals.cpp, autode/ext/src/molecule.cpp, autode/ext/src/optimisers.cpp, autode/ext/src/potentials.cpp, autode/ext/src/utils.cpp]
+# distutils: sources = [autode/ext/src/dihedrals.cpp, autode/ext/src/molecule.cpp, autode/ext/src/optimisers.cpp, autode/ext/src/potentials.cpp, autode/ext/src/utils.cpp, autode/ext/src/points.cpp]
 import numpy as np
 from autode.ext.wrappers cimport (Molecule,
                                   Dihedral,

--- a/autode/ext/ade_ext.cpp
+++ b/autode/ext/ade_ext.cpp
@@ -1,0 +1,26 @@
+#include "points.h"
+#include <iostream>
+
+using namespace std;
+using namespace autode;
+
+int main() {
+
+    CubePointGenerator pointGenerator(5,
+                                      3,
+                                      0.0,
+                                      1.0);
+
+
+
+    pointGenerator.run(1E-4, 0.01, 200);
+
+    for (auto &point : pointGenerator.points){
+        for (auto &component : point){
+            cout << component << '\t';
+        }
+        cout << endl;
+    }
+
+    return 0;
+}

--- a/autode/ext/ade_rb_opt.pyx
+++ b/autode/ext/ade_rb_opt.pyx
@@ -1,5 +1,5 @@
 # distutils: language = c++
-# distutils: sources = [autode/ext/src/dihedrals.cpp, autode/ext/src/molecule.cpp, autode/ext/src/optimisers.cpp, autode/ext/src/potentials.cpp, autode/ext/src/utils.cpp]
+# distutils: sources = [autode/ext/src/dihedrals.cpp, autode/ext/src/molecule.cpp, autode/ext/src/optimisers.cpp, autode/ext/src/potentials.cpp, autode/ext/src/utils.cpp, autode/ext/src/points.cpp]
 import numpy as np
 from libcpp.vector cimport vector
 from libcpp cimport bool as bool_t

--- a/autode/ext/include/points.h
+++ b/autode/ext/include/points.h
@@ -1,0 +1,34 @@
+#ifndef ADE_EXT_POINTS_H
+#define ADE_EXT_POINTS_H
+#include "vector"
+
+namespace autode {
+
+    class PointGenerator {
+
+        private:
+            double s_energy = 0.0;
+            std::vector<std::vector<double>> s_grad;
+
+            void set_init_random_points();
+            double norm_grad();
+
+        public:
+            int dim = 0;
+            int n = 0;
+            double min_val;
+            double max_val;
+
+            std::vector<std::vector<double>> points;
+
+            explicit PointGenerator(int n_points,
+                                    int dimension,
+                                    double min_val,
+                                    double max_val);
+
+            void set_grad();
+            void run(double grad_tol, double step_size, int max_iterations);
+    };
+}
+
+#endif //ADE_EXT_POINTS_H

--- a/autode/ext/include/points.h
+++ b/autode/ext/include/points.h
@@ -23,10 +23,10 @@ namespace autode {
             int dim = 0;
             int n = 0;
 
-            double min_val;
-            double max_val;
-            double box_length;
-            double half_box_length;
+            double min_val = 0.0;
+            double max_val = 1.0;
+            double box_length = 1.0;
+            double half_box_length = 0.5;
          
             // Gradient functions
             double norm_grad();

--- a/autode/ext/include/points.h
+++ b/autode/ext/include/points.h
@@ -4,27 +4,39 @@
 
 namespace autode {
 
-    class PointGenerator {
+    class CubePointGenerator {
 
         private:
-            double s_energy = 0.0;
+            // Attributes
             std::vector<std::vector<double>> s_grad;
+            std::vector<double> delta_point;
 
+            // Constructor helpers
             void set_init_random_points();
+            void shift_box_centre();
+
+            // Gradient functions
             double norm_grad();
+
+            // Distance functions
+            void set_delta_point_pbc(int i, int j);
+            double norm_squared_delta_point();
 
         public:
             int dim = 0;
             int n = 0;
+
             double min_val;
             double max_val;
+            double box_length;
+            double half_box_length;
 
             std::vector<std::vector<double>> points;
 
-            explicit PointGenerator(int n_points,
-                                    int dimension,
-                                    double min_val,
-                                    double max_val);
+            explicit CubePointGenerator(int n_points,
+                                        int dimension,
+                                        double min_val = -3.145,
+                                        double max_val = 3.145);
 
             void set_grad();
             void run(double grad_tol, double step_size, int max_iterations);

--- a/autode/ext/include/points.h
+++ b/autode/ext/include/points.h
@@ -15,9 +15,6 @@ namespace autode {
             void set_init_random_points();
             void shift_box_centre();
 
-            // Gradient functions
-            double norm_grad();
-
             // Distance functions
             void set_delta_point_pbc(int i, int j);
             double norm_squared_delta_point();
@@ -30,9 +27,13 @@ namespace autode {
             double max_val;
             double box_length;
             double half_box_length;
+         
+            // Gradient functions
+            double norm_grad();
 
             std::vector<std::vector<double>> points;
 
+            explicit CubePointGenerator();
             explicit CubePointGenerator(int n_points,
                                         int dimension,
                                         double min_val = -3.145,

--- a/autode/ext/src/optimisers.cpp
+++ b/autode/ext/src/optimisers.cpp
@@ -1,6 +1,6 @@
 #include "optimisers.h"
 #include "utils.h"
-#include <random>
+#include "points.h"
 #include <stdexcept>
 #include <cmath>
 
@@ -295,17 +295,16 @@ namespace autode {
         std::vector<double> min_coords;
         double min_energy = 99999999.9;
 
-        std::random_device rand_device;
-
-        std::uniform_real_distribution<double> unif_distro(-2.5, 2.5);
-        std::default_random_engine rand_generator(rand_device());
-
+        // Generate a set of points in a n-dimensional space, where n is the
+        // number of dihedrals in the system
+        CubePointGenerator generator = CubePointGenerator(max_init_points, molecule._dihedrals.size());
+        generator.run(1E-4, 0.01, 200);
 
         for (int iteration=0; iteration < max_init_points; iteration++){
 
-            for (auto &dihedral : molecule._dihedrals){
-                dihedral.angle = unif_distro(rand_generator);
-                molecule.rotate(dihedral);
+            for (size_t i=0; i < molecule._dihedrals.size(); i++){
+                molecule._dihedrals[i].angle = generator.points[iteration][i];
+                molecule.rotate(molecule._dihedrals[i]);
             }
 
             // Apply a steepest decent minimisation for a few steps

--- a/autode/ext/src/points.cpp
+++ b/autode/ext/src/points.cpp
@@ -1,5 +1,6 @@
 #include <random>
 #include <cmath>
+#include <stdexcept>
 #include "points.h"
 
 

--- a/autode/ext/src/points.cpp
+++ b/autode/ext/src/points.cpp
@@ -19,7 +19,9 @@ namespace autode {
          *
          *     dim: Dimension of the space to generate the points in
          *
-         *     min_val: Minimum value of the
+         *     min_val: Minimum value in the box (single dimension)
+         *
+         *     max_val: 
          */
         if (n_points < 2){
             throw std::runtime_error("Must have at least 2 points to generate "
@@ -35,7 +37,7 @@ namespace autode {
         this->box_length = (max_val - min_val);
         this->half_box_length = (max_val - min_val) / 2.0;
 
-        if (half_box_length < 0){
+        if (box_length < 0){
             throw std::runtime_error("Must have a positive side length. i.e. "
                                      "min_val < max_val");
         }

--- a/autode/ext/src/points.cpp
+++ b/autode/ext/src/points.cpp
@@ -1,0 +1,147 @@
+#include <random>
+#include <cmath>
+#include "points.h"
+
+namespace autode {
+
+    PointGenerator::PointGenerator(int n_points,
+                                   int dimension,
+                                   double min_val = -3.145,
+                                   double max_val = 3.145) {
+        /* Generate a set of n points evenly spaced in a cube with dimension d,
+         * with dimensions l = max_val - min_val
+         *
+         * Arguments:
+         *     n: Number of points to generate
+         *
+         *     dim: Dimension of the space to generate the points in
+         *
+         *     min_val: Minimum value of the
+         */
+        this->n = n_points;
+        this->dim = dimension;
+
+        this->min_val = min_val;
+        this->max_val = max_val;
+
+        set_init_random_points();
+    }
+
+
+    void PointGenerator::set_init_random_points(){
+        /* Set the set of points using random uniform distribution
+         */
+
+        std::random_device rand_device;
+
+        std::uniform_real_distribution<double> unif_distro(min_val, max_val);
+        std::default_random_engine rand_generator(rand_device());
+
+        // Initialise all the points randomly in the space
+        for (int i=0; i < n; i++){
+            std::vector<double> point;
+            point.reserve(dim);
+
+            // with dim members per point
+            for (int j=0; j < dim; j++){
+                point.push_back(unif_distro(rand_generator));
+            }
+
+            points.push_back(point);
+
+            // Initialise a zero gradient initially
+            s_grad.emplace_back(point.size(), 0.0);
+        }
+    }
+
+
+    double PointGenerator::norm_grad() {
+        /* Calculate the norm of the gradient vector
+         */
+        double norm = 0.0;
+
+        for (auto &grad : s_grad){
+            for (auto &component : grad){
+                norm += component * component;
+            }
+        }
+
+        return sqrt(norm);
+    }
+
+
+    void PointGenerator::set_grad(){
+        /* Calculate the gradient with respect to the points
+         *
+         *  E = Σ'_ij 1 / |x_i - x_j|
+         *
+         *  where x_i is a vector in dim-dimensional space with a distance
+         *
+         *  |x_i - x_j| = √[(x_i0 x_j0)^2 +  (x_i1 x_j1)^2  + ... ]
+         *
+         *  TODO: Periodic boundaries
+         *
+         */
+
+        for (int i=0; i < n; i++) {
+            // Zero the gradient of all (x, y, z, ..) components
+            std::fill(s_grad[i].begin(), s_grad[i].end(), 0.0);
+
+            for (int j = 0; j < n; j++) {
+
+                // Only loop over non identical pairs
+                if (i == j) {
+                    continue;
+                }
+
+
+                double r_sq = 0.0;
+
+                for (int k = 0; k < dim; k++){
+                    double d_k = points[i][k] - points[j][k];
+                    r_sq += d_k * d_k;
+                }
+
+                // Repulsion factor
+                auto rep_ftr = -1.0 / r_sq;
+
+                for (int k = 0; k < dim; k++){
+                    double d_k = points[i][k] - points[j][k];
+                    s_grad[i][k] += rep_ftr * d_k;
+                }
+
+            } // j
+        } // i
+    };
+
+
+    void PointGenerator::run(double grad_tol = 1E-4,
+                             double step_size = 0.1,
+                             int max_iterations = 100) {
+        /* Generate a set of n points evenly spaced in a dimension d. Sets
+         * PointGenerator.points. Will minimise the Coulomb energy between the
+         * points (as J. J. Thomson in 1904 in 3D) from a random starting point
+         *
+         *  Arguments:
+         *      grad_tol:
+         *
+         */
+        set_grad();
+        int iteration = 0;
+
+        while (norm_grad() > grad_tol && iteration < max_iterations){
+            for (int point_idx = 0; point_idx < n; point_idx++){
+                // Do a steepest decent step
+
+                for (int k = 0; k < dim; k ++) {
+                    points[point_idx][k] -= step_size * s_grad[point_idx][k];
+                } // k
+            }
+
+            set_grad();
+            iteration++;
+        }
+    }
+
+
+}

--- a/autode/ext/src/points.cpp
+++ b/autode/ext/src/points.cpp
@@ -21,7 +21,7 @@ namespace autode {
          *
          *     min_val: Minimum value in the box (single dimension)
          *
-         *     max_val: 
+         *     max_val:
          */
         if (n_points < 2){
             throw std::runtime_error("Must have at least 2 points to generate "

--- a/autode/ext/src/points.cpp
+++ b/autode/ext/src/points.cpp
@@ -1,5 +1,4 @@
 #include <random>
-#include <iostream>
 #include <cmath>
 #include <stdexcept>
 #include "points.h"
@@ -128,6 +127,7 @@ namespace autode {
         } // k
     }
 
+
     void CubePointGenerator::shift_box_centre(){
         /* Shift the box back such that the center is between min_val, max_val
          * in all dimensions
@@ -138,6 +138,7 @@ namespace autode {
             } // k
         }
     }
+
 
     double CubePointGenerator::norm_squared_delta_point(){
         /*
@@ -151,6 +152,7 @@ namespace autode {
 
         return norm_squared;
     }
+
 
     void CubePointGenerator::set_grad(){
         /* Calculate the gradient with respect to the points

--- a/autode/ext/tests/test_global_dihedral_min.cpp
+++ b/autode/ext/tests/test_global_dihedral_min.cpp
@@ -1,0 +1,63 @@
+#include "dihedrals.h"
+#include "optimisers.h"
+#include "molecule.h"
+#include <cmath>
+#include <vector>
+#include <catch2/catch.hpp>
+#include <iostream>
+
+using namespace autode;
+using namespace std;
+
+TEST_CASE("Test a simple dihedral optimisation of eclipsed butane"){
+
+    vector<double> coords = {-0.229521,  1.579629, -0.793611,  // x, y, z etc.
+                             0.526700,  0.459300, -0.125900,
+                             -0.533500, -0.461800,  0.494500,
+                             -1.873700,  0.093300,  0.023300,
+                             -0.309835,  1.403837, -1.900453,
+                             0.203041,  2.565908, -0.562444,
+                             -1.255677,  1.581283, -0.353641,
+                             1.122306,  0.920508,  0.696217,
+                             1.193881, -0.091622, -0.780221,
+                             -0.439200, -0.372600,  1.585900,
+                             -0.376500, -1.502200,  0.196300,
+                             -1.770000,  0.535200, -0.997800,
+                             -2.625900, -0.707300, -0.064600,
+                             -2.173700,  0.918700,  0.694900};
+
+    Molecule mol = Molecule(coords);
+    REQUIRE(mol.n_atoms == 14);
+
+    vector<bool> rotate_idxs(mol.n_atoms, false);
+    vector<int> idxs_to_rotate = {0, 4, 5, 6, 1, 7, 8};
+    for (size_t i: idxs_to_rotate){
+        rotate_idxs[i] = true;
+    }
+
+    vector<int> axis = {1, 2};
+
+    mol._dihedrals.emplace_back(0.0,       // angle
+                                axis,
+                                rotate_idxs,
+                                1);      // origin
+
+    // Pairs to consider repelling
+    vector<bool> pairs(mol.n_atoms*mol.n_atoms, false);
+    pairs[0 + 3] = true;
+    pairs[3*mol.n_atoms + 0] = true;
+
+    RDihedralPotential potential = RDihedralPotential(4,
+                                                      pairs);
+    SDDihedralOptimiser optimiser = SDDihedralOptimiser();
+    optimiser.run(potential,
+                  mol,
+                  100,   // Maximum iterations
+                  1E-5,    // Energy tolerance
+                  0.1);   // initial step size
+
+
+    // Distance between the end two carbons in the molecule should be > 3Å
+    // for the staggered conformation of butane
+    REQUIRE(mol.distance(0, 3) > 3.0);
+}

--- a/autode/ext/tests/test_main.cpp
+++ b/autode/ext/tests/test_main.cpp
@@ -1,0 +1,2 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>

--- a/autode/ext/tests/test_point_gen.cpp
+++ b/autode/ext/tests/test_point_gen.cpp
@@ -1,13 +1,14 @@
 #include "points.h"
 #include <iostream>
+#include <catch2/catch.hpp>
 
 using namespace std;
 using namespace autode;
 
-int main() {
 
-    CubePointGenerator pointGenerator(5,
-                                      3,
+TEST_CASE("Test periodic point generation in 1D"){
+    CubePointGenerator pointGenerator(2,
+                                      1,
                                       0.0,
                                       1.0);
 
@@ -21,6 +22,4 @@ int main() {
         }
         cout << endl;
     }
-
-    return 0;
 }

--- a/autode/ext/tests/test_point_gen.cpp
+++ b/autode/ext/tests/test_point_gen.cpp
@@ -1,4 +1,6 @@
 #include "points.h"
+#include <cmath>
+#include <vector>
 #include <iostream>
 #include <catch2/catch.hpp>
 
@@ -6,20 +8,91 @@ using namespace std;
 using namespace autode;
 
 
-TEST_CASE("Test periodic point generation in 1D"){
-    CubePointGenerator pointGenerator(2,
+TEST_CASE("Test point generation with only a single point"){
+
+    REQUIRE_THROWS( 
+                   CubePointGenerator(1,  // Single point
                                       1,
                                       0.0,
+                                      1.0)
+    ); 
+}
+
+
+TEST_CASE("Test the gradient used to minimise the points"){
+   
+    CubePointGenerator generator(2,  // 2 points in a 1D box with
+                                 1,  // a length of unity
+                                 0.0,
+                                 1.0);
+
+    REQUIRE(generator.half_box_length == Approx(0.5)); 
+
+    generator.n = 1;                 // Override the number of points..
+    vector<double> point(1, 0.5);
+    generator.points = {point};
+
+    // Check that for a single point the gradient is zero
+    generator.set_grad();
+    REQUIRE(generator.norm_grad() == Approx(0.0).epsilon(1E-4));
+
+}
+
+
+
+TEST_CASE("Test periodic point generation in 1D"){
+    CubePointGenerator pointGenerator(2,    // 2 points
+                                      1,    // 1D
+                                      0.0,  // minimum value
+                                      1.0); // maximum value
+
+
+                               
+    pointGenerator.run(1E-3, // Gradient tolerance 
+                       0.01, // Step size
+                       200); // Maximum number of iterations
+
+    auto points = pointGenerator.points;
+
+    REQUIRE(points.size() == 2);
+    REQUIRE(points[0].size() == 1);
+   
+    // ∆r between the two points should be 0.5 in a periodic 1D system with length of 1 
+    REQUIRE(fabs(points[0][0] - points[1][0]) == Approx(0.5).epsilon(0.05));
+}
+
+
+double distance(vector<double> point1, vector<double> point2){
+    // Calculate the Euclidean distance
+
+    double dist_sq = 0.0;
+    int dim = point1.size();
+ 
+    for (int i = 0; i < dim; i++){
+        double tmp = point1[i] - point2[i];
+        dist_sq += tmp * tmp;
+    } // i 
+ 
+    return sqrt(dist_sq);
+}
+
+
+TEST_CASE("Test periodic point generation in 3D cube"){
+    CubePointGenerator pointGenerator(4,    // 4 points 
+                                      4,    // 3D  (cube)
+                                      0.0,  // unit length
                                       1.0);
 
 
+                               
+    pointGenerator.run(1E-3, 0.01, 100);
+    auto points = pointGenerator.points;
 
-    pointGenerator.run(1E-4, 0.01, 200);
-
-    for (auto &point : pointGenerator.points){
-        for (auto &component : point){
-            cout << component << '\t';
-        }
-        cout << endl;
-    }
+    // ∆r between the two points should be 0.5 in a periodic 1D system with length of 1 
+    for (int i=0; i < 4; i++){
+        for (int j=0; j < i; j++){
+            REQUIRE(distance(points[i], points[j]) == Approx(1.0).epsilon(0.5));
+        }// j
+    }// i
 }
+

--- a/autode/ext/tests/test_point_gen.cpp
+++ b/autode/ext/tests/test_point_gen.cpp
@@ -1,7 +1,6 @@
 #include "points.h"
 #include <cmath>
 #include <vector>
-#include <iostream>
 #include <catch2/catch.hpp>
 
 using namespace std;
@@ -63,7 +62,9 @@ TEST_CASE("Test periodic point generation in 1D"){
 
 
 double distance(vector<double> point1, vector<double> point2){
-    // Calculate the Euclidean distance
+    /* Calculate the Euclidean distance between two points
+     * NOTE: Does not consider periodic boundary conditions
+    */
 
     double dist_sq = 0.0;
     int dim = point1.size();
@@ -77,22 +78,38 @@ double distance(vector<double> point1, vector<double> point2){
 }
 
 
+TEST_CASE("Test periodic point generation in 2D square"){
+    CubePointGenerator pointGenerator(2,    // 2 points
+                                      2,   // 2D  (cube)
+                                      0.0,   // unit length
+                                      1.0);
+
+
+
+    pointGenerator.run(1E-4, 0.01, 100);
+    auto points = pointGenerator.points;
+
+    // Minimum ∆r between the two points should be 0.707
+    REQUIRE(distance(points[0], points[1]) > 0.6);
+}
+
+
 TEST_CASE("Test periodic point generation in 3D cube"){
-    CubePointGenerator pointGenerator(4,    // 4 points 
-                                      4,    // 3D  (cube)
-                                      0.0,  // unit length
+    CubePointGenerator pointGenerator(4,    // 4 points
+                                      3,   // 3D  (cube)
+                                      0.0,   // unit length
                                       1.0);
 
 
                                
-    pointGenerator.run(1E-3, 0.01, 100);
+    pointGenerator.run(1E-4, 0.01, 100);
     auto points = pointGenerator.points;
 
-    // ∆r between the two points should be 0.5 in a periodic 1D system with length of 1 
+    // Minimum ∆r between two points needs to be at least 0.4, ideally
+    // it would be ~0.7 (perhaps)
     for (int i=0; i < 4; i++){
         for (int j=0; j < i; j++){
-            REQUIRE(distance(points[i], points[j]) == Approx(1.0).epsilon(0.5));
+            REQUIRE(distance(points[i], points[j]) > 0.4);
         }// j
     }// i
 }
-

--- a/tests/test_xtb_calc.py
+++ b/tests/test_xtb_calc.py
@@ -32,6 +32,7 @@ def test_xtb_calculation():
     assert calc.output.file_lines is not None
     assert calc.input.filename == 'opt_xtb.xyz'
     assert calc.output.filename == 'opt_xtb.out'
+    assert calc.optimisation_converged()
 
     with pytest.raises(NotImplementedError):
         calc.optimisation_nearly_converged()


### PR DESCRIPTION
Sampling randomly from the dihedral space randomly is almost certainly less efficient than sampling more evenly, this PR adds an initial set of points well distributed

- [x] Implement point initialisation
- [x] Initialise `SGlobalDihedralOptimiser` at each point
- [x] ~Remove test .cpp and make file~ Convert to Catch2 tests
- [x] ~Update changelog~ included in #61 