### PR TITLE
Allow for multiprocessing spawn

### DIFF
--- a/autode/utils.py
+++ b/autode/utils.py
@@ -5,7 +5,7 @@ from time import time
 from functools import wraps
 from subprocess import Popen, DEVNULL, PIPE, STDOUT
 from tempfile import mkdtemp
-import multiprocessing
+import multiprocessing as mp
 import multiprocessing.pool
 from autode.log import logger
 from autode.exceptions import (NoAtomsInMolecule,
@@ -13,8 +13,11 @@ from autode.exceptions import (NoAtomsInMolecule,
                                NoConformers,
                                NoMolecularGraph)
 
-# Needed for additional pickle-ability
-multiprocessing.set_start_method("fork")
+try:
+    mp.set_start_method("fork")
+except RuntimeError:
+    logger.warning('Multiprocessing context has already been defined')
+
 
 if sys.version_info.minor > 7:                                    # Python >3.7
     from functools import cached_property # lgtm[py/unused-import]
@@ -299,9 +302,9 @@ def timeout(seconds, return_value=None):
             p = multiprocessing.Process(target=handler,
                                         args=(q, func, args, kwargs))
 
-            try:
+            if isinstance(mp.get_context(), mp.context.ForkContext):
                 p.start()
-            except AttributeError:
+            else:
                 logger.error('Failed to wrap function')
                 return func(*args, **kwargs)
 
@@ -334,7 +337,7 @@ class NoDaemonContext(type(multiprocessing.get_context())):
     Process = NoDaemonProcess
 
 
-class NoDaemonPool(multiprocessing.pool.Pool):
+class NoDaemonPool(mp.pool.Pool):
     """Subclass of Pool to allow child multiprocessing"""
 
     def __init__(self, *args, **kwargs):

--- a/autode/utils.py
+++ b/autode/utils.py
@@ -298,7 +298,13 @@ def timeout(seconds, return_value=None):
             q = multiprocessing.Queue()
             p = multiprocessing.Process(target=handler,
                                         args=(q, func, args, kwargs))
-            p.start()
+
+            try:
+                p.start()
+            except AttributeError:
+                logger.error('Failed to wrap function')
+                return func(*args, **kwargs)
+
             p.join(timeout=seconds)
 
             if p.is_alive():

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -11,7 +11,7 @@ Usability improvements
 Usability improvements/Changes
 ******************************
 - Improves consistency and behaviour of :code:`calc_thermo` method of a species, allowing for keywords and non-run calculations
-
+- Allows for a non-fork multiprocessing 'start_method'
 
 
 1.1.2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,7 @@ from autode.wrappers.keywords import Keywords
 from autode.exceptions import NoCalculationOutput
 from autode.exceptions import NoConformers
 from autode.utils import work_in_tmp_dir
-from subprocess import Popen
+from subprocess import Popen, TimeoutExpired
 import time
 import pytest
 import os
@@ -180,13 +180,15 @@ def test_spawn_multiprocessing():
               '    with mp.Pool(2) as pool:',
               '        res = [pool.apply_async(mol) for _ in range(2)]',
               '        mols = [r.get() for r in res]',
-              file=py_file)
+              sep='\n', file=py_file)
 
     process = Popen(['python', 'tmp.py'])
-    process.wait(timeout=5)
 
     # Executing the script should not take more than a second, if the function
     # hangs then it should timeout after 5s
-    assert (time.time() - start_time) < 1
+    try:
+        process.wait(timeout=5)
+    except TimeoutExpired:
+        raise AssertionError
 
     os.remove('tmp.py')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,9 @@ from autode.wrappers.keywords import Keywords
 from autode.exceptions import NoCalculationOutput
 from autode.exceptions import NoConformers
 from autode.utils import work_in_tmp_dir
+from autode.mol_graphs import is_isomorphic
 from subprocess import Popen, TimeoutExpired
+import multiprocessing as mp
 import time
 import pytest
 import os
@@ -169,7 +171,6 @@ def test_timeout():
 
 def test_spawn_multiprocessing():
 
-    start_time = time.time()
     with open('tmp.py', 'w') as py_file:
         print('import multiprocessing as mp',
               'import autode as ade',
@@ -192,3 +193,14 @@ def test_spawn_multiprocessing():
         raise AssertionError
 
     os.remove('tmp.py')
+
+
+def test_spawn_multiprocessing_graph():
+
+    mp.set_start_method("spawn", force=True)
+
+    # Isomorphism should still be able to be checked
+    h2o_a, h2o_b = Molecule(smiles='O'), Molecule(smiles='O')
+    assert is_isomorphic(h2o_a.graph, h2o_b.graph)
+
+    mp.set_start_method('fork', force=True)


### PR DESCRIPTION
Allows for multiprocessing 'start_method' to be defined outside of autodE. Required when calling, for example PyJulia. A minimal example is:


```python
import multiprocessing as mp
import autode as ade

mp.set_start_method("spawn", force=True)


def mol():
    return ade.Molecule(atoms=[ade.Atom('H'), ade.Atom('H', x=0.7)])


if __name__ == '__main__':

    with mp.Pool(2) as pool:
        res = [pool.apply_async(mol) for _ in range(2)]
        mols = [r.get() for r in res]
```

which gets stuck in an infinite loop. This PR adds a try-except block for setting and then skips calling functions with a timeout. If anyone knows how to keep both that would be great..

**NOTE**: As far as I'm aware the set_spawn method cannot be captured by codecov, but there is a test checking that it works.

---

- [x] Test
- [x] Update changelog
- [x] Rebase when #93 is merged
