### PR TITLE
Modify Calculation get_energy

### DIFF
--- a/autode/species/species.py
+++ b/autode/species/species.py
@@ -1014,8 +1014,15 @@ class Species(AtomCollection):
 
         if calc is not None and calc.output.exists:
             self.atoms = calc.get_final_atoms()
-            self.energy = calc.get_energy()
             self.hessian = calc.get_hessian()
+
+            try:
+                self.energy = calc.get_energy()
+
+            except CalculationException:
+                logger.warning(f'Failed to get the potential energy from '
+                               f'{calc.name} but not essential for thermo'
+                               f'chemical calculation')
 
         elif self.hessian is None or (calc is not None and not calc.output.exists):
             logger.info('Calculation did not exist or Hessian was None - '
@@ -1074,13 +1081,7 @@ class Species(AtomCollection):
                          keywords=keywords,
                          n_cores=Config.n_cores if n_cores is None else n_cores)
         sp.run()
-        energy = sp.get_energy()
-
-        if energy is None:
-            raise CalculationException("Failed to calculate a single point "
-                                       f"energy for {self}")
-
-        self.energy = energy
+        self.energy = sp.get_energy()
         return None
 
     @work_in('conformers')

--- a/autode/transition_states/base.py
+++ b/autode/transition_states/base.py
@@ -295,7 +295,7 @@ class TSbase(Species, ABC):
                                  keywords=method.keywords.low_opt,
                                  reset_graph=True)
 
-                except ex.AtomsNotFound:
+                except ex.CalculationException:
                     logger.error(f'Failed to optimise {mol.name} with '
                                  f'{method}. Assuming no link')
                     return False

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -28,6 +28,8 @@ Usability improvements/Changes
 - Removes :code:`autode.KcalMol` and :code:`KjMol` and enables a reaction to be plotted using a string representation of the units.
 - Allows for keywords to be set using just a list or a string, rather than requiring a specific type
 - Changes :code:`autode.wrappers.keywords.Keyword.has_only_name` to a property
+- Modifies :code:`autode.calculation.Calculation.get_energy` to raise an exception if the energy cannot be extracted
+- Adds a runtime error if e.g. :code:`autode.calculation.Calculation.get_energy` is called on a calculation that has not been run
 
 
 Functionality improvements

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -28,12 +28,13 @@ def test_calc_class():
     assert calc.method.name == 'xtb'
     assert len(calc.input.filenames) == 0
 
-    assert calc.get_energy() is None
+    with pytest.raises(ex.CouldNotGetProperty):
+        _ = calc.get_energy()
 
     assert not calc.optimisation_converged()
     assert not calc.optimisation_nearly_converged()
 
-    with pytest.raises(ex.AtomsNotFound):
+    with pytest.raises(ex.CouldNotGetProperty):
         _ = calc.get_final_atoms()
 
     with pytest.raises(ex.CouldNotGetProperty):

--- a/tests/test_gaussian_calc.py
+++ b/tests/test_gaussian_calc.py
@@ -10,8 +10,7 @@ from autode.wrappers import keywords as kwds
 from autode.wrappers.basis_sets import def2tzecp, def2tzvp
 from autode.wrappers.functionals import pbe0
 from autode.wrappers.keywords import OptKeywords, SinglePointKeywords
-from autode.exceptions import AtomsNotFound
-from autode.exceptions import NoInputError
+from autode.exceptions import AtomsNotFound, NoInputError, CalculationException
 from autode.point_charges import PointCharge
 from autode.atoms import Atom
 from . import testutils
@@ -185,8 +184,10 @@ def test_bad_gauss_output():
     calc.output_file_lines = []
     calc.rev_output_file_lines = []
 
-    assert calc.get_energy() is None
-    with pytest.raises(AtomsNotFound):
+    with pytest.raises(CalculationException):
+        _ = calc.get_energy()
+
+    with pytest.raises(CalculationException):
         calc.get_final_atoms()
 
     with pytest.raises(NoInputError):

--- a/tests/test_mopac_calc.py
+++ b/tests/test_mopac_calc.py
@@ -129,7 +129,10 @@ def test_bad_geometry():
     calc.output.filename = 'h2_overlap_opt_mopac.out'
 
     assert not calc.terminated_normally
-    assert calc.get_energy() is None
+
+    with pytest.raises(CouldNotGetProperty):
+        _ = calc.get_energy()
+
     assert not calc.optimisation_converged()
 
 

--- a/tests/test_orca_calc.py
+++ b/tests/test_orca_calc.py
@@ -9,6 +9,7 @@ from autode.species.molecule import Molecule
 from autode.input_output import xyz_file_to_atoms
 from autode.wrappers.keywords import SinglePointKeywords, OptKeywords
 from autode.wrappers.keywords import Functional, WFMethod, BasisSet
+from autode.exceptions import CouldNotGetProperty
 from autode.solvent.solvents import ImplicitSolvent
 from autode.transition_states.transition_state import TransitionState
 from autode.transition_states.ts_guess import TSguess
@@ -137,9 +138,11 @@ def test_bad_orca_output():
     calc = Calculation(name='no_output', molecule=test_mol, method=method,
                        keywords=opt_keywords)
 
-    assert calc.get_energy() is None
-    with pytest.raises(ex.AtomsNotFound):
-        calc.get_final_atoms()
+    with pytest.raises(CouldNotGetProperty):
+        _ = calc.get_energy()
+
+    with pytest.raises(ex.CouldNotGetProperty):
+        _ = calc.get_final_atoms()
 
     with pytest.raises(ex.NoInputError):
         calc.execute_calculation()

--- a/tests/test_xtb_calc.py
+++ b/tests/test_xtb_calc.py
@@ -6,7 +6,7 @@ from autode.wrappers.XTB import XTB
 from autode.calculation import Calculation
 from autode.species.molecule import Molecule
 from autode.point_charges import PointCharge
-from autode.exceptions import AtomsNotFound
+from autode.exceptions import AtomsNotFound, CalculationException
 from autode.config import Config
 from . import testutils
 
@@ -75,7 +75,9 @@ def test_energy_extract_no_energy():
     calc.output.filename = 'h2_sp_xtb_no_energy.out'
 
     assert calc.terminated_normally
-    assert calc.get_energy() is None
+
+    with pytest.raises(CalculationException):
+        _ = calc.get_energy()
 
 
 @testutils.work_in_zipped_dir(os.path.join(here, 'data', 'xtb.zip'))


### PR DESCRIPTION
Fixes #84 by throwing a `CouldNotGetProperty` exception if an energy cannot be extracted from a completed calculation. Also adds a decorator for `Calculation` methods that require at least the name of the output filename to be set and hint that `run()` might have been forgotten to be called.