### PR TITLE
Improve TS guess functions

### DIFF
--- a/autode/atoms.py
+++ b/autode/atoms.py
@@ -587,6 +587,17 @@ class Atoms(list):
 
         return moi
 
+    @property
+    def contain_metals(self) -> bool:
+        """
+        Do these atoms contain at least a single metal atom?
+
+        -----------------------------------------------------------------------
+        Returns:
+            (bool):
+        """
+        return any(atom.label in metals for atom in self)
+
     def vector(self,
                i: int,
                j: int) -> np.ndarray:

--- a/autode/transition_states/locate_tss.py
+++ b/autode/transition_states/locate_tss.py
@@ -90,17 +90,13 @@ def ts_guess_funcs_prms(name, reactant, product, bond_rearr):
 
     # Ideally use a transition state template, then only a single constrained
     # optimisation needs to be run
-
     yield get_template_ts_guess, (r, p, bond_rearr,
                                   f'{name}_template_{bond_rearr}', hmethod)
 
-    # otherwise try a nudged elastic band calculation, don't use the low level
-    # method if there are any metals
-    if not any(atom.label in metals for atom in r.atoms):
+    if (not r.atoms.contain_metals) and hmethod != lmethod:
         yield get_ts_adaptive_path, (r, p, lmethod, bond_rearr,
                                      f'{name}_ll_ad_{bond_rearr}')
 
-    # Always attempt a high-level NEB
     yield get_ts_adaptive_path, (r, p, hmethod, bond_rearr,
                                  f'{name}_hl_ad_{bond_rearr}')
 

--- a/autode/wrappers/base.py
+++ b/autode/wrappers/base.py
@@ -249,3 +249,12 @@ class ElectronicStructureMethod(Method, ABC):
             IndexError)
         """
         raise NotImplementedError
+
+    def __eq__(self, other) -> bool:
+        """Equality of this EST method to another one"""
+
+        if not isinstance(other, self.__class__):
+            return False
+
+        attrs = ('name', 'keywords', 'path', 'implicit_solvation_type')
+        return all(getattr(other, a) == getattr(self, a) for a in attrs)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -31,6 +31,7 @@ Usability improvements/Changes
 - Modifies the constructor of :code:`autode.species.molecule.Molecule` to allow for a name to be specified when initialising from a .xyz file
 - Modifies :code:`autode.calculation.Calculation.get_energy` to raise an exception if the energy cannot be extracted
 - Adds a runtime error if e.g. :code:`autode.calculation.Calculation.get_energy` is called on a calculation that has not been run
+- Skips low-level adaptive path searching if the high and low-level methods are identical (when XTB or MOPAC are not installed)
 
 
 Functionality improvements

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -44,6 +44,7 @@ def test_atoms():
     h_atoms = Atoms([Atom('H'), Atom('H', x=1.0)])
     assert isinstance(h_atoms.com, Coordinate)
     assert np.allclose(h_atoms.com, np.array([0.5, 0.0, 0.0]))
+    assert not h_atoms.contain_metals
 
     assert h_atoms.vector(0, 1) == np.array([1.0, 0.0, 0.0])
 

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -79,3 +79,19 @@ def test_nwchem_ecps():
     assert nwchem.keywords.opt.ecp is not None
     assert nwchem.keywords.sp.ecp is not None
     assert nwchem.keywords.sp.ecp.nwchem is not None
+
+
+def test_method_equality():
+
+    orca = methods.ORCA()
+    g09 = methods.G09()
+
+    assert orca == methods.ORCA()
+    assert orca != g09
+
+    orca.keywords.sp = 'Some different keywords'
+    default_orca = methods.ORCA()
+
+    # Single point keywords are different, so the methods are different
+    assert orca.keywords.sp != default_orca.keywords.sp
+    assert orca != methods.ORCA()


### PR DESCRIPTION
This PR allows for low-level adaptive path calculations to be skipped if there is no low-level electronic structure method to use and so the low-level=high-level. Potentially enabling a 2x speedup for TSs that cannot be found. 

- [x] Update changelog