### PR TITLE
Adds ORCA version extraction

### DIFF
--- a/autode/wrappers/ORCA.py
+++ b/autode/wrappers/ORCA.py
@@ -523,7 +523,6 @@ class ORCA(ElectronicStructureMethod):
         if self.implicit_solvation_type.lower() not in ['smd', 'cpcm']:
             raise UnsuppportedCalculationInput
 
-        # Use CPCM solvation
         if (self.use_vdw_gaussian_solvent(keywords)
                 and molecule.solvent.orca not in vdw_gaussian_solvent_dict):
             err = (f'CPCM solvent with gaussian charge not available for '

--- a/autode/wrappers/ORCA.py
+++ b/autode/wrappers/ORCA.py
@@ -451,13 +451,12 @@ class ORCA(ElectronicStructureMethod):
         Get the version of ORCA without an existing output file
         """
 
-        run_external(params=[self.path, '-h'], output_filename='tmp')
-
         try:
+            run_external(params=[self.path, '-h'], output_filename='tmp')
             line = next(l for l in open('tmp', 'r') if 'Program Version' in l)
             return line.split()[2]
 
-        except StopIteration:
+        except (OSError, IOError, StopIteration):
             return '???'
 
     def get_keywords(self, calc_input, molecule):

--- a/autode/wrappers/ORCA.py
+++ b/autode/wrappers/ORCA.py
@@ -21,100 +21,6 @@ vdw_gaussian_solvent_dict = {'water': 'Water', 'acetone': 'Acetone', 'acetonitri
                              'methanol': 'Methanol', '1-octanol': 'Octanol', 'pyridine': 'Pyridine', 'tetrahydrofuran': 'THF', 'toluene': 'Toluene'}
 
 
-def use_vdw_gaussian_solvent(keywords, implicit_solv_type):
-    """
-    Determine if the calculation should use the gaussian charge scheme which
-    generally affords better convergence for optimiations in implicit solvent
-
-    Arguments:
-        keywords (autode.wrappers.keywords.Keywords):
-        implicit_solv_type (str):
-
-    Returns:
-        (bool):
-    """
-    if implicit_solv_type.lower() != 'cpcm':
-        return False
-
-    if any('freq' in kw.lower() or 'optts' in kw.lower() for kw in keywords):
-        logger.warning('Cannot do analytical frequencies with gaussian charge '
-                       'scheme - switching off')
-        return False
-
-    return True
-
-
-def add_solvent_keyword(molecule, keywords, implicit_solv_type):
-    """Add a keyword to the input file based on the solvent"""
-
-    if implicit_solv_type.lower() not in ['smd', 'cpcm']:
-        raise UnsuppportedCalculationInput
-
-    # Use CPCM solvation
-    if (use_vdw_gaussian_solvent(keywords, implicit_solv_type)
-        and molecule.solvent.orca not in vdw_gaussian_solvent_dict):
-
-        err = (f'CPCM solvent with gaussian charge not available for '
-               f'{molecule.solvent.name}. Available solvents are '
-               f'{vdw_gaussian_solvent_dict.keys()}')
-
-        raise UnsuppportedCalculationInput(message=err)
-
-    solv_name = vdw_gaussian_solvent_dict[molecule.solvent.orca]
-    keywords.append(f'CPCM({solv_name})')
-    return
-
-
-def get_keywords(calc_input, molecule, implicit_solv_type):
-    """Modify the keywords for this calculation with the solvent + fix for
-    single atom optimisation calls"""
-
-    new_keywords = []
-
-    for keyword in calc_input.keywords.copy():
-        if 'opt' in keyword.lower() and molecule.n_atoms == 1:
-            logger.warning('Can\'t optimise a single atom')
-            continue
-
-        if isinstance(keyword, kws.ECP) and keyword.orca is None:
-            # Use the default specification for applying ECPs
-            continue
-
-        if isinstance(keyword, kws.MaxOptCycles):
-            continue  # Set in print_num_optimisation_steps
-
-        if isinstance(keyword, kws.Keyword):
-            new_keywords.append(keyword.orca)
-
-        else:
-            new_keywords.append(str(keyword))
-
-    if molecule.solvent is not None:
-        add_solvent_keyword(molecule, new_keywords, implicit_solv_type)
-
-    # Sort the keywords with all the items with newlines at the end, so
-    # the first keyword line is a single contiguous line
-    return sorted(new_keywords, key=lambda kw: 1 if '\n' in kw else 0)
-
-
-def print_solvent(inp_file, molecule, keywords, implicit_solv_type):
-    """Add the solvent block to the input file"""
-    if molecule.solvent is None:
-        return
-
-    if implicit_solv_type.lower() == 'smd':
-        print(f'%cpcm\n'
-              f'smd true\n'
-              f'SMDsolvent \"{molecule.solvent.orca}\"\n'
-              f'end', file=inp_file)
-
-    if use_vdw_gaussian_solvent(keywords, implicit_solv_type):
-        print('%cpcm\n'
-              'surfacetype vdw_gaussian\n'
-              'end', file=inp_file)
-    return
-
-
 def print_added_internals(inp_file, calc_input):
     """Print the added internal coordinates"""
 
@@ -235,13 +141,12 @@ class ORCA(ElectronicStructureMethod):
 
     def generate_input(self, calc, molecule):
 
-        keywords = get_keywords(calc.input, molecule,
-                                self.implicit_solvation_type)
+        keywords = self.get_keywords(calc.input, molecule)
 
         with open(calc.input.filename, 'w') as inp_file:
             print('!', *keywords, file=inp_file)
 
-            print_solvent(inp_file, molecule, keywords, self.implicit_solvation_type)
+            self.print_solvent(inp_file, molecule, keywords)
             print_added_internals(inp_file, calc.input)
             print_distance_constraints(inp_file, molecule)
             print_cartesian_constraints(inp_file, molecule)
@@ -269,6 +174,9 @@ class ORCA(ElectronicStructureMethod):
 
     def get_version(self, calc):
         """Get the version of ORCA used to execute this calculation"""
+
+        if not calc.output.exists:
+            return self._get_version_no_output()
 
         for line in calc.output.file_lines:
             if 'Program Version' in line and len(line.split()) >= 3:
@@ -536,6 +444,115 @@ class ORCA(ElectronicStructureMethod):
 
         # Hessians printed in Ha/a0^2, so convert to base Ha/Å^2
         return np.array(hessian, dtype='f8') / Constants.a0_to_ang**2
+
+    @work_in_tmp_dir(filenames_to_copy=[], kept_file_exts=[])
+    def _get_version_no_output(self) -> str:
+        """
+        Get the version of ORCA without an existing output file
+        """
+
+        run_external(params=[self.path, '-h'], output_filename='tmp')
+
+        try:
+            line = next(l for l in open('tmp', 'r') if 'Program Version' in l)
+            return line.split()[2]
+
+        except StopIteration:
+            return '???'
+
+    def get_keywords(self, calc_input, molecule):
+        """Modify the keywords for this calculation with the solvent + fix for
+        single atom optimisation calls"""
+
+        new_keywords = []
+
+        for keyword in calc_input.keywords.copy():
+            if 'opt' in keyword.lower() and molecule.n_atoms == 1:
+                logger.warning('Can\'t optimise a single atom')
+                continue
+
+            if isinstance(keyword, kws.ECP) and keyword.orca is None:
+                # Use the default specification for applying ECPs
+                continue
+
+            if isinstance(keyword, kws.MaxOptCycles):
+                continue  # Set in print_num_optimisation_steps
+
+            if isinstance(keyword, kws.Keyword):
+                new_keywords.append(keyword.orca)
+
+            else:
+                new_keywords.append(str(keyword))
+
+        if molecule.solvent is not None:
+            self.add_solvent_keyword(molecule, new_keywords)
+
+        # Sort the keywords with all the items with newlines at the end, so
+        # the first keyword line is a single contiguous line
+        return sorted(new_keywords, key=lambda kw: 1 if '\n' in kw else 0)
+
+    def use_vdw_gaussian_solvent(self, keywords) -> bool:
+        """
+        Determine if the calculation should use the gaussian charge scheme which
+        generally affords better convergence for optimiations in implicit solvent
+
+        Arguments:
+            keywords (autode.wrappers.keywords.Keywords):
+
+        Returns:
+            (bool):
+        """
+        if self.implicit_solvation_type.lower() != 'cpcm':
+            return False
+
+        def calculates_hessians():
+            return any('freq' in w.lower() or 'optts' in w.lower() for w in keywords)
+
+        def is_orca_v5():
+            return self._get_version_no_output()[0] == '5'
+
+        if calculates_hessians() and not is_orca_v5():
+            logger.warning('Cannot do analytical frequencies with gaussian '
+                           'charge scheme - switching off')
+            return False
+
+        return True
+
+    def add_solvent_keyword(self, molecule, keywords):
+        """Add a keyword to the input file based on the solvent"""
+
+        if self.implicit_solvation_type.lower() not in ['smd', 'cpcm']:
+            raise UnsuppportedCalculationInput
+
+        # Use CPCM solvation
+        if (self.use_vdw_gaussian_solvent(keywords)
+                and molecule.solvent.orca not in vdw_gaussian_solvent_dict):
+            err = (f'CPCM solvent with gaussian charge not available for '
+                   f'{molecule.solvent.name}. Available solvents are '
+                   f'{vdw_gaussian_solvent_dict.keys()}')
+
+            raise UnsuppportedCalculationInput(message=err)
+
+        solv_name = vdw_gaussian_solvent_dict[molecule.solvent.orca]
+        keywords.append(f'CPCM({solv_name})')
+        return
+
+    def print_solvent(self, inp_file, molecule, keywords):
+        """Add the solvent block to the input file"""
+        if molecule.solvent is None:
+            return
+
+        if self.implicit_solvation_type.lower() == 'smd':
+            print(f'%cpcm\n'
+                  f'smd true\n'
+                  f'SMDsolvent \"{molecule.solvent.orca}\"\n'
+                  f'end', file=inp_file)
+
+        if self.use_vdw_gaussian_solvent(keywords):
+            print('%cpcm\n'
+                  'surfacetype vdw_gaussian\n'
+                  'end', file=inp_file)
+        return
 
 
 orca = ORCA()

--- a/tests/test_orca_calc.py
+++ b/tests/test_orca_calc.py
@@ -9,6 +9,7 @@ from autode.species.molecule import Molecule
 from autode.input_output import xyz_file_to_atoms
 from autode.wrappers.keywords import SinglePointKeywords, OptKeywords
 from autode.wrappers.keywords import Functional, WFMethod, BasisSet
+from autode.wrappers.implicit_solvent_types import cpcm
 from autode.exceptions import CouldNotGetProperty
 from autode.solvent.solvents import ImplicitSolvent
 from autode.transition_states.transition_state import TransitionState
@@ -179,6 +180,22 @@ def test_solvation():
 
     assert any('smd' in line.lower() for line in open('methane_smd_orca.inp', 'r'))
     os.remove('methane_smd_orca.inp')
+
+
+def test_vdw_solvent_not_present():
+    mol = Molecule(name='mol', smiles='C', solvent_name='2-butanol')
+
+    orca = ORCA()
+    orca.implicit_solvation_type = cpcm
+
+    calc = Calculation(name='tmp',
+                       molecule=mol,
+                       method=orca,
+                       keywords=sp_keywords)
+
+    # Cannot use gaussian charges for 2-butanol
+    with pytest.raises(ex.CalculationException):
+        calc.generate_input()
 
 
 @testutils.work_in_zipped_dir(os.path.join(here, 'data', 'orca.zip'))


### PR DESCRIPTION
This PR adds a `_get_version_no_output` method to the ORCA wrapper, which in turn enables checking if the vdw charge scheme needs to be turned off when running analytical Hessian calculations. Unfortunately, this cannot be tested in CI 😕 