### PR TITLE
Check for sufficient available memory

### DIFF
--- a/autode/units.py
+++ b/autode/units.py
@@ -263,6 +263,10 @@ hz = Unit(name='s^-1',
 # ------------------- Digital storage allocation -----------------------
 
 
+byte = Unit(name='byte',
+            conversion=1E6,      # 1,000,000 bytes = 1 MB
+            aliases=['bytes'])
+
 MB = BaseUnit(name='mb',
               aliases=['megabyte'])
 

--- a/autode/values.py
+++ b/autode/values.py
@@ -12,7 +12,7 @@ from autode.units import (Unit,
                           amu, kg, m_e,
                           amu_ang_sq, kg_m_sq,
                           ha_per_ang, ha_per_a0, ev_per_ang,
-                          MB, GB, TB)
+                          byte, MB, GB, TB)
 
 
 def _to(value: Union['Value', 'ValueArray'],
@@ -317,7 +317,7 @@ class FreeEnergyCont(Energy):
 
 class Allocation(Value):
 
-    implemented_units = [MB, GB, TB]
+    implemented_units = [byte, MB, GB, TB]
 
     def __repr__(self):
         return f'Allocation({round(self, 1)} {self.units.name})'

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -289,7 +289,7 @@ def test_exec_not_avail_method():
 
 
 @work_in_tmp_dir()
-def test_exec_too_much_memory_requested():
+def test_exec_too_much_memory_requested_py39():
 
     if sys.version_info.minor != 9:
         return  # Only supported on Python 3.9
@@ -305,3 +305,13 @@ def test_exec_too_much_memory_requested():
         run_external(['ls'], output_filename='tmp.txt')
 
     Config.max_core = curr_max_core
+
+
+@work_in_tmp_dir()
+def test_exec_too_much_memory_requested_py38():
+
+    if sys.version_info.minor != 8:
+        return  # Only supported on Python 3.8
+
+    # Python 3.8 can't use os.sysconf, so check that external can still be run
+    run_external(['ls'], output_filename='tmp.txt')


### PR DESCRIPTION
This PR adds a check that sufficient physical memory is available before running a calculation. Requested in the _autodE_ tutorial session – thanks for the suggestion 😄 