### PR TITLE
Allow G profiles with association complexes

### DIFF
--- a/autode/config.py
+++ b/autode/config.py
@@ -166,6 +166,7 @@ class _ConfigClass:
     # Flag for allowing free energies to be calculated with association
     # complexes. This is *not* recommended to be turned on due to the
     # approximations made in the entropy calculations.
+    #
     allow_association_complex_G = False
     # -------------------------------------------------------------------------
 

--- a/autode/config.py
+++ b/autode/config.py
@@ -163,6 +163,11 @@ class _ConfigClass:
     #
     min_num_atom_removed_in_truncation = 10
     # -------------------------------------------------------------------------
+    # Flag for allowing free energies to be calculated with association
+    # complexes. This is *not* recommended to be turned on due to the
+    # approximations made in the entropy calculations.
+    allow_association_complex_G = False
+    # -------------------------------------------------------------------------
 
     class ORCA:
         # ---------------------------------------------------------------------

--- a/autode/reactions/reaction.py
+++ b/autode/reactions/reaction.py
@@ -115,10 +115,12 @@ class Reaction:
         """
         logger.info('Calculating reaction profile')
 
-        if with_complexes and (free_energy or enthalpy):
+        if (not Config.allow_association_complex_G
+                and (with_complexes and (free_energy or enthalpy))):
             raise NotImplementedError('Significant likelihood of very low '
-                                      'frequency harmonic modes – G and H not '
-                                      'implemented')
+                                      'frequency harmonic modes – G and H. Set'
+                                      ' Config.allow_association_complex_G to '
+                                      'override this')
 
         @work_in(self.name)
         def calculate(reaction):


### PR DESCRIPTION
Adds a configuration flag to enable free energy profiles when association complexes are also calculated – not sensible so off by default but available for those that are feeling brave. Suggested by Thijs – thanks for the suggestion 😄 