### PR TITLE
Fixes incorrect assignment of unreasonable geometries

### DIFF
--- a/autode/reactions/reaction.py
+++ b/autode/reactions/reaction.py
@@ -11,7 +11,6 @@ from autode.log import logger
 from autode.methods import get_hmethod
 from autode.species.complex import ReactantComplex, ProductComplex
 from autode.species.molecule import Reactant, Product
-from autode.geom import are_coords_reasonable
 from autode.plotting import plot_reaction_profile
 from autode.values import Energy, PotentialEnergy, Enthalpy, FreeEnergy
 from autode.utils import work_in, requires_hl_level_methods
@@ -258,15 +257,13 @@ class Reaction:
                     + [self.ts, self._reactant_complex, self._product_complex]):
 
             if mol is None:
-                logger.warning('mol=None')
                 continue
 
             if mol.energy is None:
                 logger.warning(f'{mol.name} energy was None')
                 continue
 
-            if not are_coords_reasonable(mol.coordinates):
-                logger.warning(f'{mol.name} coordinates not reasonable')
+            if not mol.has_reasonable_coordinates:
                 continue
 
             yield mol

--- a/autode/smiles/smiles.py
+++ b/autode/smiles/smiles.py
@@ -4,7 +4,6 @@ from rdkit import Chem
 from autode.conformers.conf_gen import get_simanl_atoms
 from autode.conformers.conformers import atoms_from_rdkit_mol
 from autode.exceptions import RDKitFailed, SMILESBuildFailed
-from autode.geom import are_coords_reasonable
 from autode.log import logger
 from autode.mol_graphs import make_graph
 from autode.smiles import Parser, Builder
@@ -91,7 +90,7 @@ def init_organic_smiles(molecule, smiles):
     make_graph(molecule, bond_list=bonds)
 
     # Revert back to RR if RDKit fails to return a sensible geometry
-    if not are_coords_reasonable(coords=molecule.coordinates):
+    if not molecule.has_reasonable_coordinates:
         molecule.rdkit_conf_gen_is_fine = False
         molecule.atoms = get_simanl_atoms(molecule, save_xyz=False)
 
@@ -151,7 +150,7 @@ def init_smiles(molecule, smiles):
     for bond in parser.bonds:
         molecule.graph.edges[tuple(bond)]['pi'] = True
 
-    if not are_coords_reasonable(molecule.coordinates):
+    if not molecule.has_reasonable_coordinates:
         logger.warning('3D builder did not make a sensible geometry, '
                        'Falling back to random minimisation.')
         molecule.atoms = get_simanl_atoms(molecule, save_xyz=False)

--- a/autode/transition_states/truncation.py
+++ b/autode/transition_states/truncation.py
@@ -4,6 +4,7 @@ from autode.config import Config
 from autode.atoms import Atom
 from autode.transition_states.ts_guess import has_matching_ts_templates
 from autode.bonds import get_avg_bond_length
+from autode.mol_graphs import MolecularGraph
 from autode.log import logger
 
 
@@ -243,7 +244,7 @@ def get_truncated_species(species, bond_rearrangement):
 
     logger.info(f'Truncating {species.name} with {species.n_atoms} atoms '
                 f'around core atoms: {active_atoms}')
-    t_graph = nx.Graph()
+    t_graph = MolecularGraph()
 
     # Add all the core active atoms to the graphs, their nearest neighbours
     # and the bonds between them

--- a/doc/examples/molecules.rst
+++ b/doc/examples/molecules.rst
@@ -47,7 +47,7 @@ Molecules also add a molecular graph attribute as a `NetworkX <https://networkx.
 .. code-block:: python
 
   >>> water.graph
-  <networkx.classes.graph.Graph object at XXXXXXXXX>
+  MolecularGraph(|E| = 2, |V| = 3)
   >>> water.graph.nodes
   NodeView((0, 1, 2))
   >>> water.graph.edges

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -32,6 +32,8 @@ def test_graph_generation():
     assert h2.graph.number_of_nodes() == 2
     assert h2.graph.nodes[0]['atom_label'] == 'H'
 
+    assert 'mol' in repr(h2.graph).lower()
+
 
 def test_edge_cases():
     h_c = Atom(atomic_symbol='H', x=0.0, y=0.0, z=1.6)

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -554,3 +554,15 @@ def test_keywords_opt_sp_thermo():
         h2o.hessian = None
         h2o.calc_thermo(method=orca, keywords=kwds)
         assert h2o.energy is not None
+
+
+def test_flat_species_has_reasonable_coordinates():
+
+    _m = Molecule(atoms=[Atom('C', -4.99490, 1.95320, 0.00000),
+                         Atom('C', -4.74212, 0.64644, 0.00000),
+                         Atom('H', -4.17835, 2.66796, 0.00000),
+                         Atom('H', -6.01909, 2.31189, 0.00000),
+                         Atom('H', -3.71793, 0.28776, -0.00000),
+                         Atom('H', -5.55867, -0.06831, 0.00000)])
+
+    assert _m.has_reasonable_coordinates


### PR DESCRIPTION
Closes #126 

As of v1.2.0 the `geom.are_coords_reasonable()` failed to classify any >3 atom planar structures aligned in the xy-plane as reasonable. This PR adds two methods (`atoms.Atoms.are_planar`, `graphs.MolecularGraph.expected_planar_geometry`) to correct this.

*** 
### TODO

- [ ] Run NWChem DA profile
- [ ] Refactor are_coords_reasonable function