### PR TITLE
Fix for missed output redirection

### DIFF
--- a/autode/__init__.py
+++ b/autode/__init__.py
@@ -33,7 +33,7 @@ So, you want to bump the version.. make sure the following steps are followed
   - Merge when tests pass
 """
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'
 
 
 __all__ = [

--- a/autode/calculation.py
+++ b/autode/calculation.py
@@ -580,7 +580,8 @@ class CalculationOutput:
         if self.filename is None or not os.path.exists(self.filename):
             raise ex.NoCalculationOutput
 
-        return open(self.filename, 'r', encoding="utf-8").readlines()
+        file = open(self.filename, 'r', encoding='utf-8', errors='ignore')
+        return file.readlines()
 
     @property
     def exists(self) -> bool:

--- a/autode/utils.py
+++ b/autode/utils.py
@@ -2,7 +2,7 @@ import os
 import sys
 import shutil
 from time import time
-from typing import Any, Optional, List
+from typing import Any, Optional, Sequence
 from functools import wraps
 from subprocess import Popen, PIPE, STDOUT
 from tempfile import mkdtemp
@@ -99,8 +99,10 @@ def run_external(params, output_filename):
 
 
 @check_sufficient_memory
-def run_external_monitored(params, output_filename, break_word='MPI_ABORT',
-                           break_words=None):
+def run_external_monitored(params:          Sequence[str],
+                           output_filename: str,
+                           break_word:      str = 'MPI_ABORT',
+                           break_words:     Optional[str] = None):
     """
     Run an external process monitoring the standard output and error for a
     word that will terminate the process
@@ -111,7 +113,6 @@ def run_external_monitored(params, output_filename, break_word='MPI_ABORT',
 
         output_filename (str):
 
-    Keyword Arguments:
         break_word (str): String that if found will terminate the process
 
         break_words (list(str) | None): List of break_word-s
@@ -173,8 +174,8 @@ def work_in(dir_ext):
     return func_decorator
 
 
-def work_in_tmp_dir(filenames_to_copy: Optional[List[str]] = None,
-                    kept_file_exts:    Optional[List[str]] = None,
+def work_in_tmp_dir(filenames_to_copy: Optional[Sequence[str]] = None,
+                    kept_file_exts:    Optional[Sequence[str]] = None,
                     use_ll_tmp:        bool = False):
     """Execute a function in a temporary directory.
 

--- a/autode/wrappers/XTB.py
+++ b/autode/wrappers/XTB.py
@@ -2,13 +2,13 @@ import os
 import shutil
 import numpy as np
 from autode.wrappers.base import ElectronicStructureMethod
-from autode.utils import run_external_monitored
+from autode.utils import run_external
 from autode.wrappers.keywords import OptKeywords, GradientKeywords
 from autode.atoms import Atom
 from autode.config import Config
 from autode.constants import Constants
 from autode.exceptions import AtomsNotFound, CouldNotGetProperty
-from autode.utils import work_in_tmp_dir
+from autode.utils import work_in_tmp_dir, run_in_tmp_environment
 from autode.log import logger
 
 
@@ -162,14 +162,13 @@ class XTB(ElectronicStructureMethod):
         @work_in_tmp_dir(filenames_to_copy=calc.input.filenames,
                          kept_file_exts=('.xyz', '.out', '.pc', '.grad'),
                          use_ll_tmp=True)
+        @run_in_tmp_environment(OMP_NUM_THREADS=calc.n_cores,
+                                GFORTRAN_UNBUFFERED_ALL=1)
         def execute_xtb():
-            logger.info(f'Setting the number of OMP threads to {calc.n_cores}')
-            os.environ['OMP_NUM_THREADS'] = str(calc.n_cores)
 
             logger.info(f'Running XTB with: {" ".join(flags)}')
-            run_external_monitored(
-                params=[calc.method.path, calc.input.filename]+flags,
-                output_filename=calc.output.filename)
+            run_external(params=[calc.method.path, calc.input.filename]+flags,
+                         output_filename=calc.output.filename)
 
             if os.path.exists('gradient'):
                 shutil.move('gradient', f'{calc.name}_OLD.grad')

--- a/autode/wrappers/XTB.py
+++ b/autode/wrappers/XTB.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import numpy as np
 from autode.wrappers.base import ElectronicStructureMethod
-from autode.utils import run_external
+from autode.utils import run_external_monitored
 from autode.wrappers.keywords import OptKeywords, GradientKeywords
 from autode.atoms import Atom
 from autode.config import Config
@@ -167,8 +167,9 @@ class XTB(ElectronicStructureMethod):
             os.environ['OMP_NUM_THREADS'] = str(calc.n_cores)
 
             logger.info(f'Running XTB with: {" ".join(flags)}')
-            run_external(params=[calc.method.path, calc.input.filename]+flags,
-                         output_filename=calc.output.filename)
+            run_external_monitored(
+                params=[calc.method.path, calc.input.filename]+flags,
+                output_filename=calc.output.filename)
 
             if os.path.exists('gradient'):
                 shutil.move('gradient', f'{calc.name}_OLD.grad')

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,6 +2,18 @@ Changelog
 =========
 
 
+1.2.2
+--------
+----------
+
+Bugfix release.
+
+
+Bug Fixes
+*********
+- Fixes output redirection from XTB calculations resulting in missed lines on Mac
+
+
 1.2.1
 --------
 ----------

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ extensions = [Extension('cconf_gen', ['autode/conformers/cconf_gen.pyx']),
                         extra_link_args=["-std=c++11"])]
 
 setup(name='autode',
-      version='1.2.1',
+      version='1.2.2',
       packages=['autode',
                 'autode.conformers',
                 'autode.pes',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -229,3 +229,21 @@ def test_requires_graph():
         m.graph = None
 
         f(m)  # No graph
+
+
+def test_tmp_env():
+
+    os.environ['OMP_NUM_THREADS'] = '1'
+
+    @utils.run_in_tmp_environment(tmp_key_str='tmp_value',
+                                  tmp_key_int=1,
+                                  OMP_NUM_THREADS=9999)
+    def f():
+        assert os.environ['tmp_key_int'] == '1'
+        assert os.environ['tmp_key_str'] == 'tmp_value'
+        assert os.environ['OMP_NUM_THREADS'] == '9999'
+
+    f()
+    assert 'tmp_key_int' not in os.environ
+    assert 'tmp_key_str' not in os.environ
+    assert os.environ['OMP_NUM_THREADS'] == '1'


### PR DESCRIPTION
Fixes #132 

Context: Redirecting stdout generated from XTB calculations on Mac OS 12 can result in missed output.

This PR sets `GFORTRAN_UNBUFFERED_ALL=1` as a temporary environment variable while executing XTB, which seems to fix the problem (suggested in https://github.com/duartegroup/autodE/issues/132#issuecomment-1073656157). Unfortunately, without appropriate hardware/OS on GH runners this can't be tested, but locally it seems to work.

@matthewtoholland I'd appreciate if you could pull this branch and see if it fixes it for you too – thanks 👌 