### PR TITLE
Adds atom classes

### DIFF
--- a/autode/atoms.py
+++ b/autode/atoms.py
@@ -478,6 +478,9 @@ class Atom:
 
         return None
 
+    def copy(self) -> 'Atom':
+        return deepcopy(self)
+
     # --- Method aliases ---
     coordinate = coord
 

--- a/autode/atoms.py
+++ b/autode/atoms.py
@@ -740,7 +740,7 @@ class AtomCollection:
     def __init__(self,
                  atoms: Union[List[Atom], Atoms, None] = None):
         """
-        Collection of atoms, used as a a base class for a species, complex
+        Collection of atoms, used as a base class for a species, complex
         or transition state.
 
         -----------------------------------------------------------------------

--- a/autode/atoms.py
+++ b/autode/atoms.py
@@ -13,7 +13,8 @@ class Atom:
                  atomic_symbol: str,
                  x:             float = 0.0,
                  y:             float = 0.0,
-                 z:             float = 0.0):
+                 z:             float = 0.0,
+                 atom_class:    Optional[int] = None):
         """
         Atom class. Centered at the origin by default. Can be initialised from
         positional or keyword arguments:
@@ -32,17 +33,23 @@ class Atom:
 
         -----------------------------------------------------------------------
         Arguments:
-            atomic_symbol (str): Symbol of an element e.g. 'C' for carbon
+            atomic_symbol: Symbol of an element e.g. 'C' for carbon
 
-        Keyword Arguments:
-            x (float): x coordinate in 3D space (Å)
-            y (float): y coordinate in 3D space (Å)
-            z (float): z coordinate in 3D space (Å)
+            x: x coordinate in 3D space (Å)
+
+            y: y coordinate in 3D space (Å)
+
+            z: z coordinate in 3D space (Å)
+
+            atom_class: Fictitious additional labels to distinguish otherwise
+                        identical atoms. Useful in finding bond isomorphisms
+                        over identity reactions
         """
         assert atomic_symbol in elements
 
         self.label = atomic_symbol
         self._coord = Coordinate(float(x), float(y), float(z))
+        self.atom_class = atom_class
 
     def __repr__(self):
         """

--- a/autode/calculation.py
+++ b/autode/calculation.py
@@ -339,6 +339,10 @@ class Calculation:
             raise ex.AtomsNotFound(f'Failed to get atoms from '
                                    f'{self.output.filename}')
 
+        # Atom classes are persistent when calculations are performed
+        for old_atom, new_atom in zip(self.molecule.atoms, atoms):
+            new_atom.atom_class = old_atom.atom_class
+
         return atoms
 
     @_requires_set_output_filename

--- a/autode/calculation.py
+++ b/autode/calculation.py
@@ -178,7 +178,7 @@ class Calculation:
         if not os.path.exists(register_name):
             logger.info('No calculations have been performed here yet')
             append_register()
-            return
+            return None
 
         # Populate a register of calculation names and their unique identifiers
         register = {}
@@ -189,13 +189,13 @@ class Calculation:
 
         if is_identical():
             logger.info('Calculation has already been run')
-            return
+            return None
 
         # If this calculation doesn't yet appear in the register add it
         if not exists():
             logger.info('This calculation has not yet been run')
             append_register()
-            return
+            return None
 
         # If we're here then this calculation - with these input - has not yet
         # been run. Therefore, add an integer to the calculation name until
@@ -209,7 +209,7 @@ class Calculation:
             logger.info(f'New calculation name is: {self.name}')
 
             if is_identical():
-                return
+                return None
 
             if not exists():
                 append_register()
@@ -457,7 +457,7 @@ class Calculation:
 
         if Config.keep_input_files and not force:
             logger.info('Keeping input files')
-            return
+            return None
 
         filenames = self.input.filenames
         if everything:

--- a/autode/conformers/conformer.py
+++ b/autode/conformers/conformer.py
@@ -145,9 +145,9 @@ class Conformer(Species):
         set the coordinates as a batch
         """
 
-        if value is None:
+        if value is None:  # Clear the coordinates
             self._coordinates = None
-            return  # Nothing to do
+            return None
 
         if self._parent_atoms is None:
             self._parent_atoms = value

--- a/autode/conformers/conformers.py
+++ b/autode/conformers/conformers.py
@@ -153,7 +153,7 @@ class Conformers(list):
         if len(self) < 2:
             logger.info(f'Only have {len(self)} conformers. No need to prune '
                         f'on RMSD')
-            return
+            return None
 
         rmsd_tol = Config.rmsd_threshold if rmsd_tol is None else rmsd_tol
 
@@ -225,7 +225,7 @@ class Conformers(list):
         # TODO: Test efficiency + improve with dynamic load balancing
         if len(self) == 0:
             logger.error(f'Cannot run {calc_type} over 0 conformers')
-            return
+            return None
 
         n_cores_pp = max(Config.n_cores // len(self), 1)
 

--- a/autode/conformers/conformers.py
+++ b/autode/conformers/conformers.py
@@ -183,7 +183,7 @@ class Conformers(list):
         return None
 
     def prune_diff_graph(self,
-                         graph: 'networkx.Graph'
+                         graph: 'autode.mol_graphs.MolecularGraph'
                          ) -> None:
         """
         Remove conformers with a different molecular graph to a defined
@@ -193,7 +193,7 @@ class Conformers(list):
         -----------------------------------------------------------------------
 
         Arguments:
-            graph (networkx.Graph): Reference graph
+            graph: Reference graph
         """
         n_prev_confs = len(self)
 

--- a/autode/mol_graphs.py
+++ b/autode/mol_graphs.py
@@ -100,6 +100,7 @@ def make_graph(species:                'autode.Species',
     Raises:
         NoAtomsInMolecule:
     """
+
     if species.n_atoms == 0:
         raise ex.NoAtomsInMolecule('Could not build a molecular graph with no '
                                    'atoms')

--- a/autode/smiles/base.py
+++ b/autode/smiles/base.py
@@ -1,6 +1,7 @@
 import enum
 import numpy as np
-from typing import Union
+
+from typing import Optional
 from autode.log import logger
 from autode.atoms import Atom
 from autode.exceptions import InvalidSmilesString
@@ -27,22 +28,25 @@ class SMILESAtom(Atom):
     def __init__(self,
                  label:       str,
                  stereochem:  SMILESStereoChem = SMILESStereoChem.NONE,
-                 n_hydrogens: Union[None, int] = None,
-                 charge:      int = 0):
+                 n_hydrogens: Optional[int] = None,
+                 charge:      int = 0,
+                 atom_class:  Optional[int] = None):
         """
         SMILES atom initialised at the origin
 
         ----------------------------------------------------------------------
         Arguments:
-            label (str): Label / atomic symbol of this atom
+            label: Label / atomic symbol of this atom
 
-        Keyword Arguments:
-            n_hydrogens (int | None): Number of hydrogens, None means unset and
-                                      should be determined implicitly
+            n_hydrogens: Number of hydrogens, None means unset and should be
+                         determined implicitly
 
-            stereochem (SMILESStereoChem):
+            stereochem: Point stereochemistry around this atom (R, S)
 
-            charge (int): Formal charge on this atom
+            charge: Formal charge on this atom
+
+            atom_class: Class of an atom. See §3.1.7 in the SMILES spec
+                        http://opensmiles.org/opensmiles.html
         """
         super().__init__(atomic_symbol=label.capitalize())
 
@@ -52,6 +56,7 @@ class SMILESAtom(Atom):
         self.charge = charge
         self.n_hydrogens = n_hydrogens
         self.stereochem = stereochem
+        self.atom_class = atom_class
 
         # ---------- Attributes used for building the 3D structure ----------
         self.type = None

--- a/autode/smiles/builder.py
+++ b/autode/smiles/builder.py
@@ -5,6 +5,7 @@ from autode.log import logger
 from autode.utils import log_time
 from autode.atoms import Atom, AtomCollection
 from autode.bonds import get_avg_bond_length
+from autode.mol_graphs import MolecularGraph
 from autode.smiles.base import SMILESAtom, SMILESBond, SMILESStereoChem
 from autode.smiles.angles import SDihedral, SDihedrals, SAngle, SAngles
 from ade_dihedrals import rotate, closed_ring_coords
@@ -65,7 +66,8 @@ class Builder(AtomCollection):
         atoms = []
         for atom in self.atoms:
             x, y, z = atom.coord
-            atoms.append(Atom(atom.label, x=x, y=y, z=z))
+            atoms.append(Atom(atom.label, x=x, y=y, z=z,
+                              atom_class=atom.atom_class))
 
         return atoms
 
@@ -931,7 +933,7 @@ class Builder(AtomCollection):
 
         # Set attributes
         self.atoms, self.bonds = atoms, bonds
-        self.graph = nx.Graph()
+        self.graph = MolecularGraph()
         self.queued_atoms = []
         self.queued_dihedrals = SDihedrals()
 

--- a/autode/smiles/parser.py
+++ b/autode/smiles/parser.py
@@ -70,7 +70,7 @@ class Parser:
 
     def _check_smiles(self):
         """Check the SMILES string for unsupported characters"""
-        present_invalid_chars = [c for c in ('.', '*') if c in self._string]
+        present_invalid_chars = [char for char in ('.', '*') if char in self._string]
 
         if len(present_invalid_chars) > 0:
             raise InvalidSmilesString(f'{self._string} had invalid characters:'
@@ -540,7 +540,7 @@ def atomic_n_hydrogens(string):
     return 0
 
 
-def atomic_class(string) -> Optional[int]:
+def atomic_class(string: str) -> Optional[int]:
     """Extract the atomic class from a string i.e.::
 
         H4:2  -> 2
@@ -552,21 +552,26 @@ def atomic_class(string) -> Optional[int]:
         return None
 
     digits = string.split(':')[1]
-    return int(digits)
+
+    try:
+        return int(digits)
+
+    except ValueError:
+        raise InvalidSmilesString("")
 
 
-def next_char(string, idx):
+def next_char(string: str, idx: int) -> str:
     """
     Get the next character in a string if it exists otherwise return
     an empty string
 
     ---------------------------------------------------------------------------
     Arguments:
-        string (str):
-        idx (idx): Index of the current position in the string
+        string:
+        idx: Index of the current position in the string
 
     Returns:
-        (str): Next character in the string
+        Next character in the string
     """
     if idx >= len(string) - 1:
         return ''

--- a/autode/smiles/parser.py
+++ b/autode/smiles/parser.py
@@ -6,6 +6,8 @@
 
 as of 03/2021
 """
+from typing import Optional
+
 from autode.log import logger
 from autode.utils import log_time
 from autode.atoms import elements
@@ -68,8 +70,7 @@ class Parser:
 
     def _check_smiles(self):
         """Check the SMILES string for unsupported characters"""
-        present_invalid_chars = [char for char in (':', '.', '*')
-                                 if char in self._string]
+        present_invalid_chars = [c for c in ('.', '*') if c in self._string]
 
         if len(present_invalid_chars) > 0:
             raise InvalidSmilesString(f'{self._string} had invalid characters:'
@@ -99,6 +100,7 @@ class Parser:
 
         e.g. [C], [CH3], [Cu+2], [O-], [C@H]
         """
+
         if '(' in string or ')' in string:
             raise InvalidSmilesString('Cannot parse branch in "[]" section')
 
@@ -133,7 +135,8 @@ class Parser:
         atom = SMILESAtom(label=label,
                           n_hydrogens=atomic_n_hydrogens(rest),
                           charge=atomic_charge(rest),
-                          stereochem=atomic_sterochem(rest))
+                          stereochem=atomic_sterochem(rest),
+                          atom_class=atomic_class(rest))
 
         self.atoms.append(atom)
         return None
@@ -535,6 +538,21 @@ def atomic_n_hydrogens(string):
                 return 1
 
     return 0
+
+
+def atomic_class(string) -> Optional[int]:
+    """Extract the atomic class from a string i.e.::
+
+        H4:2  -> 2
+        :7    -> 7
+        :001  -> 1
+    """
+
+    if ':' not in string:
+        return None
+
+    digits = string.split(':')[1]
+    return int(digits)
 
 
 def next_char(string, idx):

--- a/autode/smiles/smiles.py
+++ b/autode/smiles/smiles.py
@@ -87,10 +87,10 @@ def init_organic_smiles(molecule, smiles):
     method.randomSeed = 0xf00d
     AllChem.EmbedMultipleConfs(rdkit_mol, numConfs=1, params=method)
     molecule.atoms = atoms_from_rdkit_mol(rdkit_mol, conf_id=0)
-    make_graph(molecule, bond_list=bonds)
 
-    # Revert back to RR if RDKit fails to return a sensible geometry
+    # Revert to RR if RDKit fails to return a sensible geometry
     if not molecule.has_reasonable_coordinates:
+
         molecule.rdkit_conf_gen_is_fine = False
         molecule.atoms = get_simanl_atoms(molecule, save_xyz=False)
 
@@ -109,6 +109,10 @@ def init_organic_smiles(molecule, smiles):
 
     check_bonds(molecule, bonds=rdkit_mol.GetBonds())
 
+    for atom, smiles_atom in zip(molecule.atoms, parser.atoms):
+        atom.atom_class = smiles_atom.atom_class
+
+    make_graph(species=molecule, bond_list=bonds)
     molecule.rdkit_mol_obj = rdkit_mol
     return None
 
@@ -141,11 +145,11 @@ def init_smiles(molecule, smiles):
     except (SMILESBuildFailed, NotImplementedError):
         molecule.atoms = builder.canonical_atoms_at_origin
 
-    make_graph(molecule, bond_list=parser.bonds)
-
     for idx, atom in enumerate(builder.atoms):
         if atom.has_stereochem:
             molecule.graph.nodes[idx]['stereo'] = True
+
+        molecule.atoms[idx].atom_class = parser.atoms[idx].atom_class
 
     for bond in parser.bonds:
         molecule.graph.edges[tuple(bond)]['pi'] = True
@@ -156,6 +160,7 @@ def init_smiles(molecule, smiles):
         molecule.atoms = get_simanl_atoms(molecule, save_xyz=False)
 
     check_bonds(molecule, bonds=parser.bonds)
+    make_graph(molecule, bond_list=parser.bonds)
 
     return None
 

--- a/autode/smiles/smiles.py
+++ b/autode/smiles/smiles.py
@@ -107,12 +107,12 @@ def init_organic_smiles(molecule, smiles):
             molecule.graph.nodes[idx_i]['stereo'] = True
             molecule.graph.nodes[idx_j]['stereo'] = True
 
-    check_bonds(molecule, bonds=rdkit_mol.GetBonds())
-
     for atom, smiles_atom in zip(molecule.atoms, parser.atoms):
         atom.atom_class = smiles_atom.atom_class
 
     make_graph(species=molecule, bond_list=bonds)
+    check_bonds(molecule, bonds=rdkit_mol.GetBonds())
+
     molecule.rdkit_mol_obj = rdkit_mol
     return None
 
@@ -149,7 +149,8 @@ def init_smiles(molecule, smiles):
         if atom.has_stereochem:
             molecule.graph.nodes[idx]['stereo'] = True
 
-        molecule.atoms[idx].atom_class = parser.atoms[idx].atom_class
+    make_graph(molecule, bond_list=parser.bonds)
+    check_bonds(molecule, bonds=parser.bonds)
 
     for bond in parser.bonds:
         molecule.graph.edges[tuple(bond)]['pi'] = True
@@ -158,9 +159,6 @@ def init_smiles(molecule, smiles):
         logger.warning('3D builder did not make a sensible geometry, '
                        'Falling back to random minimisation.')
         molecule.atoms = get_simanl_atoms(molecule, save_xyz=False)
-
-    check_bonds(molecule, bonds=parser.bonds)
-    make_graph(molecule, bond_list=parser.bonds)
 
     return None
 

--- a/autode/species/molecule.py
+++ b/autode/species/molecule.py
@@ -66,9 +66,6 @@ class Molecule(Species):
         if smiles is not None:
             self._init_smiles(smiles)
 
-        elif atoms is not None:
-            make_graph(self)
-
         # If the name is unassigned use a more interpretable chemical formula
         if name == 'molecule' and self.atoms is not None:
             self.name = self.formula

--- a/autode/species/species.py
+++ b/autode/species/species.py
@@ -666,7 +666,7 @@ class Species(AtomCollection):
         Returns:
             (bool):
         """
-        if self.n_atoms == 0:
+        if self.n_atoms < 2:
             return True
 
         dist_matrix = distance_matrix(self.coordinates, self.coordinates)

--- a/autode/species/species.py
+++ b/autode/species/species.py
@@ -226,7 +226,10 @@ class Species(AtomCollection):
         """
         Molecular graph with atoms(V) and bonds(E)
 
-        Note: Graphs are lazily evaluated
+        Note: Graphs are lazily evaluated, i.e. if one has not been generated
+        for this species before and it does have atoms then a graph will be
+        generated. Subsequent accesses of this property will use the cached
+        internal/private self._graph attribute
         """
         if self.atoms is None:
             logger.warning('Had no atoms, so no molecular graph')

--- a/autode/transition_states/base.py
+++ b/autode/transition_states/base.py
@@ -65,16 +65,10 @@ class TSbase(Species, ABC):
 
     def _init_graph(self) -> None:
         """Set the molecular graph for this TS object from the reactant"""
+
         if self.reactant is not None:
             logger.warning(f'Setting the graph of {self.name} from reactants')
-            self.graph = self.reactant.graph.copy()
-
-        elif self.atoms is not None:
-            logger.warning(f'Setting the graph of {self.name} from atoms')
-            make_graph(self)
-
-        else:
-            logger.warning('Have no TS graph')
+            self._graph = self.reactant.graph.copy()
 
         return None
 

--- a/autode/utils.py
+++ b/autode/utils.py
@@ -139,7 +139,7 @@ def run_external_monitored(params:          Sequence[str],
         except ChildProcessError:
             logger.warning('External terminated')
             proc.terminate()
-            return
+            return None
 
     return None
 

--- a/autode/wrappers/XTB.py
+++ b/autode/wrappers/XTB.py
@@ -30,7 +30,7 @@ class XTB(ElectronicStructureMethod):
         """Add distance constraints to the input file"""
 
         if molecule.constraints.distance is None:
-            return
+            return None
 
         for (i, j), dist in molecule.constraints.distance.items():
             # XTB counts from 1 so increment atom ids by 1
@@ -38,13 +38,13 @@ class XTB(ElectronicStructureMethod):
                   f'force constant={self.force_constant}\n'
                   f'distance:{i+1}, {j+1}, {dist:.4f}\n$',
                   file=inp_file)
-        return
+        return None
 
     def print_cartesian_constraints(self, inp_file, molecule):
         """Add cartesian constraints to an xtb input file"""
 
         if molecule.constraints.cartesian is None:
-            return
+            return None
 
         constrained_atom_idxs = [i + 1 for i in molecule.constraints.cartesian]
         list_of_ranges, used_atoms = [], []
@@ -65,14 +65,15 @@ class XTB(ElectronicStructureMethod):
               f'force constant={self.force_constant}\n'
               f'atoms: {",".join(list_of_ranges)}\n'
               f'$', file=inp_file)
-        return
+
+        return None
 
     @staticmethod
     def print_point_charge_file(calc):
         """Generate a point charge file"""
 
         if calc.input.point_charges is None:
-            return
+            return None
 
         with open(f'{calc.name}_xtb.pc', 'w') as pc_file:
             print(len(calc.input.point_charges), file=pc_file)
@@ -83,7 +84,7 @@ class XTB(ElectronicStructureMethod):
                 print(f'{charge:^12.8f} {x:^12.8f} {y:^12.8f} {z:^12.8f}', file=pc_file)
 
         calc.input.additional_filenames.append(f'{calc.name}_xtb.pc')
-        return
+        return None
 
     def print_xcontrol_file(self, calc, molecule):
         """Print an XTB input file with constraints and point charges"""

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,8 +18,7 @@ Usability improvements/Changes
 
 Functionality improvements
 **************************
-
--
+- Adds the ability to define atom classes for molecules in turn allowing for identity reactions to be calculated
 
 
 Bug Fixes

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,6 +14,7 @@ Usability improvements/Changes
 - All exceptions now inherit from a base :code:`autode.exceptions.AutodeException`
 - Fixes a typo in :code:`autode.exceptions.UnsupoportedCalculationInput`
 - Adds documentation explaining the intention of each exception in  :code:`autode.exceptions`
+- Molecular graphs are now 'laziliy-loaded' i.e. generated once when the property is accessed
 
 
 Functionality improvements

--- a/doc/examples/reactions.rst
+++ b/doc/examples/reactions.rst
@@ -76,3 +76,25 @@ To optimise the reactants and products then locate the transition state using
   >>> rxn.delta('E‡').to('kcal mol-1')
   Energy(14.30068 kcal mol-1)
 
+
+Identity reactions where reactants and products are identical are not, by default,
+supported in **autode** as the bond rearrangement of interest is not easily inferred.
+However, reactions profiles for identity reactions may be calculated by defining
+*atom classes* to distinguish otherwise identical atoms. For example
+
+.. code-block:: python
+
+  >>> rxn = ade.Reaction('[Br-:1].C[Br:2]>>C[Br:1].[Br-:2]', solvent_name='water')
+  >>> # bond rearrangement leading to products is well defined
+  >>> rxn.calculate_reaction_profile()
+
+calculates the profile for the Br- + CH3Br -> BrCH3 + Br- SN2 reaction. An
+:code:`atom.atom_class` attribute is set when defined in the SMILES string. This
+may be set directly, with the following two molecules being identical
+
+.. code-block:: python
+
+  >>> mol_a = ade.Molecule(smiles='[He:1]')
+  >>> mol_b = ade.Molecule(atoms=[ade.Atom('He', atom_class=1)])
+  >>> mol_a.atoms[0].atom_class == mol_b.atoms[0].atom_class == 1
+  True

--- a/doc/examples/reactions.rst
+++ b/doc/examples/reactions.rst
@@ -79,7 +79,7 @@ To optimise the reactants and products then locate the transition state using
 
 Identity reactions where reactants and products are identical are not, by default,
 supported in **autode** as the bond rearrangement of interest is not easily inferred.
-However, reactions profiles for identity reactions may be calculated by defining
+However, reaction profiles for identity reactions may be calculated by defining
 *atom classes* to distinguish otherwise identical atoms. For example
 
 .. code-block:: python

--- a/tests/test_atoms.py
+++ b/tests/test_atoms.py
@@ -405,3 +405,12 @@ def test_atoms_collection_doc_examples():
                            Atom('H', 2.1446, 0.8424, 0.7276)])
 
     assert np.isclose(h2s2.dihedral(2, 0, 1, 3).to('deg'), -90.0, atol=0.1)
+
+
+def test_atom_copy():
+
+    a = atoms.Atom('H')
+    b = a.copy()
+    a.label = 'C'
+
+    assert b.label == 'H'

--- a/tests/test_bond_rearrangement.py
+++ b/tests/test_bond_rearrangement.py
@@ -3,13 +3,13 @@ import pytest
 import networkx as nx
 import autode as ade
 from autode import bond_rearrangement as br
+from autode.mol_graphs import MolecularGraph
 from autode.species.molecule import Molecule
 from autode.bond_rearrangement import BondRearrangement
 from autode.species.complex import ReactantComplex, ProductComplex
 from autode.atoms import Atom
 from autode.mol_graphs import is_isomorphic
 from autode.mol_graphs import make_graph
-from autode.geom import get_neighbour_list
 
 
 # Some of the 'reactions' here are not physical, hence for some the graph will
@@ -234,8 +234,8 @@ def test_add_bond_rearrang():
 
 
 def test_generate_rearranged_graph():
-    init_graph = nx.Graph()
-    final_graph = nx.Graph()
+    init_graph = MolecularGraph()
+    final_graph = MolecularGraph()
     init_edges = [(0, 1), (1, 2), (2, 3), (4, 5), (5, 6)]
     final_edges = [(0, 1), (2, 3), (3, 4), (4, 5), (5, 6)]
     for edge in init_edges:

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -20,7 +20,7 @@ h_b = Atom(atomic_symbol='H', x=0.0, y=0.0, z=0.7)
 h2 = Species(name='H2', atoms=[h_a, h_b], charge=0, mult=1)
 mol_graphs.make_graph(h2)
 
-g = nx.Graph()
+g = mol_graphs.MolecularGraph()
 edges = [(0, 1), (1, 2), (2, 0), (0, 3), (3, 4)]
 for edge in edges:
     g.add_edge(*edge)
@@ -169,7 +169,7 @@ def test_reac_to_prods():
     rearrang = BondRearrangement([(0, 4)], [(3, 4)])
     prod_graph = mol_graphs.reac_graph_to_prod_graph(g, rearrang)
     expected_edges = [(0, 1), (1, 2), (2, 0), (0, 3), (0, 4)]
-    expected_graph = nx.Graph()
+    expected_graph = mol_graphs.MolecularGraph()
     for edge in expected_edges:
         expected_graph.add_edge(*edge)
 
@@ -208,17 +208,7 @@ def test_set_pi_bonds():
 
 def test_species_isomorphism():
 
-    h2.graph = None
     h2_copy = Species(name='H2', atoms=[h_a, h_b], charge=0, mult=1)
-    h2_copy.graph = None
-
-    with pytest.raises(NoMolecularGraph):
-        assert mol_graphs.species_are_isomorphic(h2, h2_copy)
-
-    # With molecular graphs the species should be isomorphic
-    mol_graphs.make_graph(h2)
-    mol_graphs.make_graph(h2_copy)
-
     assert mol_graphs.species_are_isomorphic(h2, h2_copy)
 
     # Shift one of the atoms far away and remake the graph
@@ -254,7 +244,7 @@ def test_isomorphic_no_active():
 def test_timeout():
 
     # Generate a large-ish graph
-    graph = nx.Graph()
+    graph = mol_graphs.MolecularGraph()
     for i in range(10000):
         graph.add_node(i)
 

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -18,10 +18,6 @@ here = os.path.dirname(os.path.abspath(__file__))
 
 def test_basic_attributes():
 
-    with pytest.raises(NoAtomsInMolecule):
-        Molecule(atoms=[])
-        Molecule()
-
     methane = Molecule(name='methane', smiles='C')
 
     assert methane.name == 'methane'

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -263,3 +263,9 @@ def test_defined_metal_spin_state():
 
     mol = Molecule(smiles='[Sc]C', mult=3)
     assert mol.mult == 3
+
+
+def test_atom_class_defined_for_organic():
+
+    mol = Molecule(smiles='[Br-:1]')
+    assert mol.atoms[0].atom_class is not None

--- a/tests/test_reaction_class.py
+++ b/tests/test_reaction_class.py
@@ -483,7 +483,4 @@ def test_identity_reaction_is_supported_with_labels():
     assert reaction_is_isomorphic(isomorphic_rxn)
 
     rxn = reaction.Reaction('[Br-:1].C[Br:2]>>C[Br:1].[Br-:2]')
-    print(rxn.reacs[0].graph.nodes(data=True))
-
-    print(rxn.reactant.graph.nodes(data=True))
     assert not reaction_is_isomorphic(rxn)

--- a/tests/test_reaction_class.py
+++ b/tests/test_reaction_class.py
@@ -472,3 +472,18 @@ def test_name_uniqueness():
                             Product(smiles='C[C]([H])C'))
 
     assert rxn.reacs[0].name != rxn.prods[0].name
+
+
+def test_identity_reaction_is_supported_with_labels():
+
+    def reaction_is_isomorphic(_r):
+        return _r.reactant.graph.is_isomorphic_to(_r.product.graph)
+
+    isomorphic_rxn = reaction.Reaction('[Br-].C[Br]>>C[Br].[Br-]')
+    assert reaction_is_isomorphic(isomorphic_rxn)
+
+    rxn = reaction.Reaction('[Br-:1].C[Br:2]>>C[Br:1].[Br-:2]')
+    print(rxn.reacs[0].graph.nodes(data=True))
+
+    print(rxn.reactant.graph.nodes(data=True))
+    assert not reaction_is_isomorphic(rxn)

--- a/tests/test_reaction_class.py
+++ b/tests/test_reaction_class.py
@@ -226,9 +226,13 @@ def test_calc_delta_e():
     r2 = reaction.Reactant(name='h', atoms=[Atom('H')])
     r2.energy = -0.5
 
-    tsguess = TSguess(atoms=None,
-                      reactant=ReactantComplex(r1),
+    reac_complex = ReactantComplex(r1)
+    assert reac_complex.graph is not None
+
+    tsguess = TSguess(atoms=reac_complex.atoms,
+                      reactant=reac_complex,
                       product=ProductComplex(r2.to_product()))
+
     tsguess.bond_rearrangement = BondRearrangement()
     ts = TransitionState(tsguess)
     ts.energy = -0.8
@@ -241,8 +245,6 @@ def test_calc_delta_e():
 
     assert -1E-6 < reac.delta('E') < 1E-6
     assert 0.2 - 1E-6 < reac.delta('E‡') < 0.2 + 1E-6
-
-    # Without calculated
 
 
 def test_from_smiles():

--- a/tests/test_smiles_parser.py
+++ b/tests/test_smiles_parser.py
@@ -459,6 +459,12 @@ def is_invalid(smiles):
         Parser().parse(smiles)
 
 
+def is_valid(smiles):
+
+    Parser().parse(smiles)  # Throws if invalid
+    return True
+
+
 def test_parse_ring_idx():
 
     # % ring closures must be followed by two numbers
@@ -496,3 +502,8 @@ def test_parse_smiles_with_labels_with_h():
 
     parser.parse('[CH4:2]')
     assert next(a for a in parser.atoms if a.label == "C").atom_class == 2
+
+
+def test_parse_h3o_cation_smiles():
+
+    assert is_valid('[O+H2]')

--- a/tests/test_smiles_parser.py
+++ b/tests/test_smiles_parser.py
@@ -477,3 +477,22 @@ def test_parse_ring_idx():
     parser._string = 'CCCC'
     with pytest.raises(InvalidSmilesString):
         parser._parse_ring_idx(idx=0)
+
+
+def test_parse_smiles_with_labels_no_h():
+
+    parser = Parser()
+    parser.parse('C[Br:777]')
+
+    assert sum(["Br" == atom.atomic_symbol for atom in parser.atoms]) == 1
+
+    br_atom = next(a for a in parser.atoms if a.label == "Br")
+    assert br_atom.atom_class == 777
+
+
+def test_parse_smiles_with_labels_with_h():
+
+    parser = Parser()
+
+    parser.parse('[CH4:2]')
+    assert next(a for a in parser.atoms if a.label == "C").atom_class == 2

--- a/tests/test_smiles_parser.py
+++ b/tests/test_smiles_parser.py
@@ -507,3 +507,10 @@ def test_parse_smiles_with_labels_with_h():
 def test_parse_h3o_cation_smiles():
 
     assert is_valid('[O+H2]')
+
+
+def test_parse_smiles_atom_class():
+
+    assert is_valid('[H:1]')
+    is_invalid('[H:1.1]')
+    is_invalid('[H:a]')

--- a/tests/test_species.py
+++ b/tests/test_species.py
@@ -64,9 +64,9 @@ def test_species_class():
 
     assert water.formula == 'H2O' or water.formula == 'OH2'
 
-    # Species without a molecular graph cannot define a bond matrix
-    with pytest.raises(ValueError):
-        _ = water.bond_matrix
+    # Species without a molecular graph (no atoms) cannot define a bond matrix
+    with pytest.raises(Exception):
+        _ = Molecule().bond_matrix
 
     # very approximate molecular radius
     assert 0.5 < water.radius < 2.5
@@ -126,11 +126,10 @@ def test_connectivity():
     # Must have the same connectivity as itself
     assert _h2.has_same_connectivity_as(_h2)
 
-    # Undetermined if one doesn't have a graph
-    _h2_no_graph = _h2.copy()
-    _h2_no_graph.graph = None
-    with pytest.raises(ValueError):
-        _h2.has_same_connectivity_as(_h2_no_graph)
+    # Graphs are lazy loaded so if undefined one is built
+    _h2_no_set = _h2.copy()
+    _h2_no_set.graph = None
+    _h2.has_same_connectivity_as(_h2_no_set)
 
     # Or something without a graph attribute is passed
     with pytest.raises(ValueError):
@@ -345,11 +344,8 @@ def test_generate_conformers():
 
 def test_set_lowest_energy_conformer():
 
-    from autode.mol_graphs import make_graph
-
     hb = Atom('H', z=0.7)
     hydrogen = Species(name='H2', atoms=[h1, hb], charge=0, mult=1)
-    make_graph(hydrogen)
 
     hydrogen_wo_e = Species(name='H2', atoms=[h1, hb], charge=0, mult=1)
 


### PR DESCRIPTION
Closes #138 

Allows for atom classes to be defined in a SMILES string as per §3.1.7 of the openSMILES [spec](http://opensmiles.org/opensmiles.html). This allows TSs for identity reactions to be determined, where different atom classes are defined. For example

```python
import autode as ade

r = ade.Reaction('[Br-:1].C[Br:2]>>C[Br:1].[Br-:2]', solvent_name='water')
r.calculate_reaction_profile()
```
should work.

*** 
TODO:

- [x] Update changlog
- [x] Add end-to-end test
- [x] Test with more complex reactions
- [x] Check that the atom indexing doesn't have to be enforced
- [x] Update changlog with lazy loading info
- [ ] ~Use same names for reactants and products~ Maybe worth being more general with this. Computing a hash containing the initial structure then going to a DB of conformationally searched molecules