### PR TITLE
Exits working directory if wrapped function throws an exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ If **autodE** is used in a publication please consider citing the [paper](https:
 - Kjell Jorner ([@kjelljorner](https://github.com/kjelljorner))
 - Thibault Lestang ([@tlestang](https://github.com/tlestang))
 - Domen Pregeljc ([@dpregeljc](https://github.com/dpregeljc))
+- Jonathon Vandezande ([@jevandezande](https://github.com/jevandezande))

--- a/autode/utils.py
+++ b/autode/utils.py
@@ -143,13 +143,15 @@ def work_in(dir_ext: str):
                 os.mkdir(dir_path)
 
             os.chdir(dir_path)
-            result = func(*args, **kwargs)
-            os.chdir(here)
+            try:
+                result = func(*args, **kwargs)
+            finally:
+                os.chdir(here)
 
-            if len(os.listdir(dir_path)) == 0:
-                logger.warning(f'Worked in {dir_path} but made no files '
-                               f'- deleting')
-                os.rmdir(dir_path)
+                if len(os.listdir(dir_path)) == 0:
+                    logger.warning(f'Worked in {dir_path} but made no files '
+                                   f'- deleting')
+                    os.rmdir(dir_path)
 
             return result
 
@@ -204,20 +206,23 @@ def work_in_tmp_dir(filenames_to_copy: Optional[Sequence[str]] = None,
             # Move directories and execute
             os.chdir(tmpdir_path)
 
-            logger.info('Function   ...running')
-            result = func(*args, **kwargs)
-            logger.info('           ...done')
+            try:
+                logger.info('Function   ...running')
+                result = func(*args, **kwargs)
+                logger.info('           ...done')
 
-            for filename in os.listdir(tmpdir_path):
+                for filename in os.listdir(tmpdir_path):
 
-                if any([filename.endswith(ext) for ext in kept_file_exts]):
-                    logger.info(f'Copying back {filename}')
-                    shutil.copy(filename, here)
+                    if any([filename.endswith(ext) for ext in kept_file_exts]):
+                        logger.info(f'Copying back {filename}')
+                        shutil.copy(filename, here)
 
-            os.chdir(here)
+            finally:
+                os.chdir(here)
 
-            logger.info('Removing temporary directory')
-            shutil.rmtree(tmpdir_path)
+                logger.info('Removing temporary directory')
+                shutil.rmtree(tmpdir_path)
+
             return result
 
         return wrapped_function

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,20 @@ def test_clear_files():
     os.rmdir('test')
 
 
+def test_reset_dir_on_error():
+    @utils.work_in("tmp_path")
+    def raise_error():
+        assert 0
+
+    here = os.getcwd()
+    try:
+        raise_error()
+    except AssertionError:
+        pass
+
+    assert here == os.getcwd()
+
+
 def test_monitored_external():
 
     echo = ['echo', 'test']
@@ -75,6 +89,20 @@ def test_work_in_temp_dir():
 
     os.remove('echo_test.py')
     os.remove('test.txt')
+
+
+def test_reset_tmp_dir_on_error():
+    @utils.work_in_tmp_dir()
+    def raise_error():
+        assert 0
+
+    here = os.getcwd()
+    try:
+        raise_error()
+    except AssertionError:
+        pass
+
+    assert here == os.getcwd()
 
 
 @work_in_tmp_dir(filenames_to_copy=[], kept_file_exts=[])


### PR DESCRIPTION
If a function wrapped with `@utils.work_in` or `@utils.work_in_tmp_dir` throws an exception that is later caught, the working directory will be in the wrong location.

Note: `@utils.work_in` may have an unintended side-effect (unaffected by this PR). If an empty directory is passed to `@utils.work_in`, and nothing is produced in that directory, the directory will be deleted.