### PR TITLE
Add checking for incompatible charge/mult

### DIFF
--- a/autode/__init__.py
+++ b/autode/__init__.py
@@ -38,7 +38,7 @@ Bumping the version number requires following the release proceedure:
   - Merge when tests pass
 """
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 
 __all__ = [

--- a/autode/species/molecule.py
+++ b/autode/species/molecule.py
@@ -87,12 +87,26 @@ class Molecule(Species):
             smiles (str):
         """
         at_strings = re.findall(r"\[.*?]", smiles)
+        init_charge, init_mult = self._charge, self._mult
 
         if any(metal in string for metal in metals for string in at_strings):
             init_smiles(self, smiles)
 
         else:
             init_organic_smiles(self, smiles)
+
+        if not _is_default_mult(init_mult) and init_mult != self._mult:
+            logger.warning(
+                "Specified multiplicity did not match SMILES "
+                "calculated value - using the former"
+            )
+            self._mult = init_mult
+
+        if not _is_default_charge(init_charge) and init_charge != self._charge:
+            raise ValueError(
+                "SMILES charge was not the same as the "
+                f"defined value. {self._charge} ≠ {init_charge}"
+            )
 
         logger.info(
             f"Initialisation with SMILES successful. "
@@ -242,3 +256,11 @@ class Reactant(Molecule):
 
 class Product(Molecule):
     """Product molecule"""
+
+
+def _is_default_mult(value) -> bool:
+    return value == 1
+
+
+def _is_default_charge(value) -> bool:
+    return value == 0

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+1.3.3
+--------
+----------
+
+Bugfix release.
+
+
+Bug Fixes
+*********
+- Adds checking of SMILES-defined charge and multiplicity against user-specified values
+
+
 1.3.2
 --------
 ----------

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extensions = [
 
 setup(
     name="autode",
-    version="1.3.2",
+    version="1.3.3",
     python_requires=">3.7",
     packages=[
         "autode",

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -271,3 +271,18 @@ def test_atom_class_defined_for_organic():
 
     mol = Molecule(smiles="[Br-:1]")
     assert mol.atoms[0].atom_class is not None
+
+
+def test_smiles_and_user_defined_charge_raises_exception():
+
+    with pytest.raises(Exception):
+        _ = Molecule(smiles="[Cl-]", charge=1)
+
+
+def test_user_defined_charge_overrides_smiles_mult():
+
+    ch2 = Molecule(smiles="[H][C][H]")
+    default_mult = ch2.mult
+
+    ch2_alt = Molecule(smiles="[H][C][H]", mult=3 if default_mult == 1 else 1)
+    assert ch2_alt.mult != default_mult


### PR DESCRIPTION
Adds a warning if the SMILES-calculated multiplicity doesn't match a non-default specified value and an exception if the charge doesn't match. Suggest using different behaviour between spin multiplicity and charge due to – I think – the former not being able to be specified in a SMILES string

### TODO:

- [ ] Add metal-complex test e.g. HS dn
