### PR TITLE
Fix cleanup with null filename

### DIFF
--- a/autode/calculations/executors.py
+++ b/autode/calculations/executors.py
@@ -199,7 +199,7 @@ class CalculationExecutor:
 
         logger.info(f"Deleting: {set(filenames)}")
 
-        for filename in set(filenames):
+        for filename in [fn for fn in set(filenames) if fn is not None]:
 
             try:
                 os.remove(filename)


### PR DESCRIPTION
## Resolves #223 

Note: with the example in #223 there is now no exception thrown, but I don't think any files are actually deleted 😕 