### PR TITLE
Add "ERROR" level to logging

### DIFF
--- a/autode/log/log.py
+++ b/autode/log/log.py
@@ -3,7 +3,7 @@ import os
 
 """
 Set up logging with the standard python logging module. Set the log level with
-$AUTODE_LOG_LEVEL = {'', INFO, WARNING, DEBUG}
+$AUTODE_LOG_LEVEL = {'', ERROR, WARNING, INFO, DEBUG}
 
 i.e. export AUTODE_LOG_LEVEL=DEBUG
 
@@ -35,7 +35,7 @@ def get_log_level():
 
     if log_level_str == "INFO":
         return logging.INFO
-    
+
     if log_level_str == "ERROR":
         return logging.ERROR
 

--- a/autode/log/log.py
+++ b/autode/log/log.py
@@ -35,6 +35,9 @@ def get_log_level():
 
     if log_level_str == "INFO":
         return logging.INFO
+    
+    if log_level_str == "ERROR":
+        return logging.ERROR
 
     return logging.CRITICAL
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,25 @@
 Changelog
 =========
 
+1.3.5
+--------
+----------
+
+
+Usability improvements/Changes
+******************************
+*
+
+
+Functionality improvements
+**************************
+-
+
+
+Bug Fixes
+*********
+- Fixes :code:`ERROR` logging level being ignored from environment variable :code:`AUTODE_LOG_LEVEL`
+
 1.3.4
 --------
 ----------

--- a/doc/config.rst
+++ b/doc/config.rst
@@ -136,7 +136,7 @@ to see all the options.
 Logging
 -------
 
-To set the logging level to one of {INFO, WARNING, ERROR} set the :code:`AUTODE_LOG_LEVEL`
+To set the logging level to one of {DEBUG, INFO, WARNING, ERROR} set the :code:`AUTODE_LOG_LEVEL`
 environment variable, in bash::
 
     $ export AUTODE_LOG_LEVEL=INFO

--- a/doc/reference/log.rst
+++ b/doc/reference/log.rst
@@ -11,7 +11,7 @@ Logging
 Logging
 -------
 
-To set the logging level to one of {INFO, WARNING, ERROR} set the AUTODE_LOG_LEVEL
+To set the logging level to one of {DEBUG, INFO, WARNING, ERROR} set the AUTODE_LOG_LEVEL
 environment variable, in bash::
 
     $ export AUTODE_LOG_LEVEL=INFO

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -14,6 +14,9 @@ def test_log_level():
     os.environ["AUTODE_LOG_LEVEL"] = "DEBUG"
     assert log.get_log_level() == log.logging.DEBUG
 
+    os.environ["AUTODE_LOG_LEVEL"] = "ERROR"
+    assert log.get_log_level() == log.logging.ERROR
+
     os.environ["AUTODE_LOG_LEVEL"] = "WARNING"
     assert log.get_log_level() == log.logging.WARNING
 


### PR DESCRIPTION
AutodE did not previously recognise the ERROR level of logging if set by "export AUTODE_LOG_LEVEL=ERROR".


***

## Checklist

* [x] The changes include an associated explanation of how/why
* [x] Test pass
* [x] Documentation has been updated
* [x] Update changelog
