### PR TITLE
Autouse temp config context manager

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,10 @@ def autouse_fixture():
     # Frequencies are all with unity scaling
     ade.Config.freq_scale_factor = 1.0
 
-    yield  # test happens here
+    # Use bad quality plots for speed
+    ade.Config.high_quality_plots = False
+
+    with ade.utils.temporary_config():
+        yield  # test happens here
 
     # Teardown

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -310,14 +310,11 @@ def test_exec_too_much_memory_requested_above_py39():
     # Normal external run should be fine
     run_external(["whoami"], output_filename="tmp.txt")
 
-    curr_max_core = deepcopy(Config.max_core)
     Config.max_core = 10000000000000
 
     # But if there is not enough physical memory it should raise an exception
     with pytest.raises(RuntimeError):
         run_external(["whoami"], output_filename="tmp.txt")
-
-    Config.max_core = curr_max_core
 
 
 @requires_with_working_xtb_install

--- a/tests/test_conf_gen.py
+++ b/tests/test_conf_gen.py
@@ -13,7 +13,6 @@ import numpy as np
 import os
 
 here = os.path.dirname(os.path.abspath(__file__))
-Config.n_cores = 1
 
 butane = Molecule(
     name="butane",

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -10,6 +10,7 @@ here = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_get_hmethod():
+
     Config.hcode = None
     Config.ORCA.path = here  # A path that exists
 
@@ -51,9 +52,6 @@ def test_get_lmethod():
 
     method4 = methods.get_lmethod()
     assert method4.name == "mopac"
-
-    # Back to default
-    Config.lcode = None
 
 
 def test_method_unavailable():

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -21,7 +21,6 @@ import pytest
 import os
 
 here = os.path.dirname(os.path.abspath(__file__))
-Config.high_quality_plots = False
 
 
 def test_plot_reaction_profile():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -388,8 +388,8 @@ def test_temporary_config_in_worker_proc():
             job = pool.submit(worker_fn)
             _ = job.result()
 
-    Config.n_cores = old_n_cores
-    Config.ORCA.keywords.sp.functional = old_orca_funct
+    assert Config.n_cores == old_n_cores
+    assert Config.ORCA.keywords.sp.functional == old_orca_funct
 
 
 def test_time_units():


### PR DESCRIPTION
<!--
Please replace _#ISSUE_ with just e.g. #12 if this PR resolves issue 12.
-->
## Resolves #227 

This was surprisingly easy – thought there would be more places where the Config was modified and then needed to be put back. Seems to work as intended

***

## Checklist

* [x] The changes include an associated explanation of how/why
* [x] Test pass
* [x] ~Documentation has been updated~ Not needed
