### PR TITLE
Fix tests that use xTB on Windows

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -453,11 +453,7 @@ def test_requires_xtb_install():
 
     # if XTB is in $PATH, the function should execute
     xtbpath = shutil.which("xtb")
-    if xtbpath is None:
-        return
-
-    assert xtbpath.lower().endswith(("xtb", "xtb.exe"))
-
-    tmp_function()
-
-    assert len(test_list) == 1
+    if xtbpath is not None:
+         assert xtbpath.lower().endswith(("xtb", "xtb.exe"))
+         tmp_function()
+         assert len(test_list) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -456,9 +456,8 @@ def test_requires_xtb_install():
     if xtbpath is None:
         return
 
-    if not xtbpath.lower().endswith(("xtb", "xtb.exe")):
-        return
-    else:
-        tmp_function()
+    assert xtbpath.lower().endswith(("xtb", "xtb.exe"))
+
+    tmp_function()
 
     assert len(test_list) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -454,6 +454,6 @@ def test_requires_xtb_install():
     # if XTB is in $PATH, the function should execute
     xtbpath = shutil.which("xtb")
     if xtbpath is not None:
-         assert xtbpath.lower().endswith(("xtb", "xtb.exe"))
-         tmp_function()
-         assert len(test_list) == 1
+        assert xtbpath.lower().endswith(("xtb", "xtb.exe"))
+        tmp_function()
+        assert len(test_list) == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -301,3 +301,15 @@ def test_requires_xtb_install():
     # If XTB is not in $PATH then the function should not execute
     assert len(test_list) == 0
     os.environ["PATH"] = path_env_var
+
+    # if XTB is in $PATH, the function should execute
+    xtbpath = shutil.which("xtb")
+    if xtbpath is None:
+        return
+
+    if not xtbpath.lower().endswith(("xtb", "xtb.exe")):
+        return
+    else:
+        tmp_function()
+
+    assert len(test_list) == 1

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -55,8 +55,7 @@ def requires_with_working_xtb_install(func):
         if not shutil.which("xtb"):
             return
 
-        xtb_path = shutil.which("xtb").lower()
-        if not (xtb_path.endswith("xtb") or xtb_path.endswith("xtb.exe")):
+        if not shutil.which("xtb").lower().endswith(("xtb", "xtb.exe")):
             return
 
         return func(*args, **kwargs)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -52,7 +52,11 @@ def requires_with_working_xtb_install(func):
 
     @wraps(func)
     def wrapped_function(*args, **kwargs):
-        if not shutil.which("xtb") or not shutil.which("xtb").endswith("xtb"):
+        if not shutil.which("xtb"):
+            return
+
+        xtb_path = shutil.which("xtb").lower()
+        if not (xtb_path.endswith("xtb") or xtb_path.endswith("xtb.exe")):
             return
 
         return func(*args, **kwargs)


### PR DESCRIPTION
The decorator `@requires_with_working_xtb_install` would previously always return on Windows since the `.exe` extension is returned by shutil. This PR fixes that bug.

(I didn't update the changelog because this should be covered under making autodE run on windows, I just didn't notice the issue in the previous PR)

***

## Checklist

* [x] The changes include an associated explanation of how/why
* [x] Test pass
* [x] Documentation has been updated
* [x] Changelog has been updated
