### PR TITLE
Add option to change xTB parameterisation version and temperature

### DIFF
--- a/autode/config.py
+++ b/autode/config.py
@@ -340,12 +340,12 @@ class _ConfigClass:
         #
         # Electronic temperature for all calculations (Kelvin)
         # None means unset (default), set to 300.0 to have 300K for example
-        etemp = None
+        electronic_temp = None
         #
         # Version of xTB hamiltonian parameterisation: 0,1 or 2
         # corresponding to GFN0-xTB, GFN1-xTB, GFN2-xTB respectively
         # When unset, uses the default
-        gfn_ver = None
+        gfn_version = None
 
     class MOPAC:
         # ---------------------------------------------------------------------

--- a/autode/config.py
+++ b/autode/config.py
@@ -337,6 +337,15 @@ class _ConfigClass:
         # Force constant used for harmonic restraints in constrained
         # optimisations (Ha/a0)
         force_constant = 2
+        #
+        # Electronic temperature for all calculations (Kelvin)
+        # None means unset (default), set to 300.0 to have 300K for example
+        etemp = None
+        #
+        # Version of xTB hamiltonian parameterisation: 0,1 or 2
+        # corresponding to GFN0-xTB, GFN1-xTB, GFN2-xTB respectively
+        # When unset, uses the default
+        gfn_ver = None
 
     class MOPAC:
         # ---------------------------------------------------------------------

--- a/autode/wrappers/XTB.py
+++ b/autode/wrappers/XTB.py
@@ -24,8 +24,8 @@ class XTB(autode.wrappers.methods.ExternalMethodOEG):
         )
 
         self.force_constant = Config.XTB.force_constant
-        self.etemp = Config.XTB.etemp
-        self.gfn_ver = Config.XTB.gfn_ver
+        self.electronic_temp = Config.XTB.electronic_temp
+        self.gfn_version = Config.XTB.gfn_version
 
     def __repr__(self):
         return f"XTB(available = {self.is_available})"
@@ -168,10 +168,12 @@ class XTB(autode.wrappers.methods.ExternalMethodOEG):
             "--uhf",
             str(calc.molecule.mult - 1),
         ]
-        if self.etemp is not None:
-            flags.extend(["--etemp", str(float(self.etemp))])
-        if self.gfn_ver is not None:
-            flags.extend(["--gfn", str(self.gfn_ver)])
+        if self.electronic_temp is not None:
+            flags.extend(
+                ["--electronic_temp", str(float(self.electronic_temp))]
+            )
+        if self.gfn_version is not None:
+            flags.extend(["--gfn", str(self.gfn_version)])
 
         if isinstance(calc.input.keywords, OptKeywords):
             if calc.input.keywords.max_opt_cycles is not None:

--- a/autode/wrappers/XTB.py
+++ b/autode/wrappers/XTB.py
@@ -169,9 +169,7 @@ class XTB(autode.wrappers.methods.ExternalMethodOEG):
             str(calc.molecule.mult - 1),
         ]
         if self.electronic_temp is not None:
-            flags.extend(
-                ["--electronic_temp", str(float(self.electronic_temp))]
-            )
+            flags.extend(["--etemp", str(float(self.electronic_temp))])
         if self.gfn_version is not None:
             flags.extend(["--gfn", str(self.gfn_version)])
 

--- a/autode/wrappers/XTB.py
+++ b/autode/wrappers/XTB.py
@@ -24,6 +24,8 @@ class XTB(autode.wrappers.methods.ExternalMethodOEG):
         )
 
         self.force_constant = Config.XTB.force_constant
+        self.etemp = Config.XTB.etemp
+        self.gfn_ver = Config.XTB.gfn_ver
 
     def __repr__(self):
         return f"XTB(available = {self.is_available})"
@@ -166,6 +168,10 @@ class XTB(autode.wrappers.methods.ExternalMethodOEG):
             "--uhf",
             str(calc.molecule.mult - 1),
         ]
+        if self.etemp is not None:
+            flags.extend(["--etemp", str(float(self.etemp))])
+        if self.gfn_ver is not None:
+            flags.extend(["--gfn", str(self.gfn_ver)])
 
         if isinstance(calc.input.keywords, OptKeywords):
             if calc.input.keywords.max_opt_cycles is not None:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,6 +14,7 @@ Usability improvements/Changes
 ******************************
 - Adds full usability of autodE on Windows, including parallelisation with :code:`loky`
 - Optional timeout for graph isomorphism test in Windows, turned on by :code:`Config.use_experimental_timeout=True` (default behaviour kept for Linux/macOS)
+- The electronic temperature and the version of parameterisation for xTB calculations are made configurable
 
 
 Bug Fixes

--- a/tests/test_wrappers/test_xtb.py
+++ b/tests/test_wrappers/test_xtb.py
@@ -416,6 +416,5 @@ def test_xtb_temp_var_params():
 
     # xTB command line flags should be printed in the output
     assert output.find("--gfn 1") != -1
-    assert output.find("GFN1-XTB") != -1
     etemp_str = str(float(1200.1))  # string repr may be different
     assert output.find(f"--etemp {etemp_str}") != -1


### PR DESCRIPTION
Adds options to change the xTB `--etemp` and `--gfn` flags from Config. Default values (None) prevent use of those flags.


***

## Checklist

* [x] The changes include an associated explanation of how/why
* [x] Test pass
* [x] Documentation has been updated
* [x] Changelog has been updated
