### PR TITLE
Fix RFO hessian update bug

### DIFF
--- a/autode/opt/optimisers/rfo.py
+++ b/autode/opt/optimisers/rfo.py
@@ -34,7 +34,7 @@ class RFOptimiser(NDOptimiser):
         """RFO step"""
         logger.info("Taking a RFO step")
 
-        self._coords.h_inv = self._updated_h_inv()
+        self._coords.h = self._updated_h()
 
         h_n, _ = self._coords.h.shape
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -19,6 +19,7 @@ Usability improvements/Changes
 Bug Fixes
 *********
 - Fixes pickling issue with :code:`autode.config.Config` on Windows and in multiprocessing spawn for Linux/macOS
+- Fixes RFO Hessian update bug
 
 
 1.3.5


### PR DESCRIPTION
## Resolves #253 

Hessian is updated in RFO, as Hessian is used for step instead of augmented Hessian
***

## Checklist

* [x] The changes include an associated explanation of how/why
* [x] Test pass
* [x] Documentation has been updated
* [x] Changelog has been updated
