### PR TITLE
Add exception for NEB init with <3 images

### DIFF
--- a/autode/neb/original.py
+++ b/autode/neb/original.py
@@ -517,6 +517,9 @@ class NEB:
                 "Cannot construct a NEB from species with different atoms"
             )
 
+        if num < 3:
+            raise ValueError("Cannot create a NEB with fewer than 3 images")
+
         neb = cls.from_list(
             species_list=cls._interpolated_species(initial, final, n=num),
             init_k=init_k,

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -18,7 +18,7 @@ Usability improvements/Changes
 - The electronic temperature and the version of parameterisation for xTB calculations are made configurable
 - A NEB :code:`Image` now derives from a :code:`Species` superclass
 - Modifies NEB :code:`Image` constructor to be formed from an image
-- Defines named constructors (:code:`from_endpoints(...)`, :code:`from_list(...)`) for :code:`NEB`
+- Defines named constructors (:code:`from_end_points(...)`, :code:`from_list(...)`) for :code:`NEB`
 - Removes :code:`NEB().contains_peak()` in favour of :code:`NEB().images.contains_peak`
 - Modifies the :code:`CImages` constructor to ensure it's constructed from an :code:`Images` instance
 - Removes :code:`NEB.get_species_saddle_point()` in favour of :code:`NEB.peak_species`

--- a/tests/test_neb.py
+++ b/tests/test_neb.py
@@ -421,3 +421,11 @@ def test_constructing_neb_from_endpoints_with_different_atoms_raises():
         _ = NEB.from_end_points(
             Molecule(smiles="O"), Molecule(smiles="C"), num=4
         )
+
+
+def test_neb_from_endpoints_requires_at_least_3_images():
+
+    with pytest.raises(Exception):
+        _ = NEB.from_end_points(
+            Molecule(smiles=r"C\C=C\C"), Molecule(smiles=r"C\C=C/C"), num=2
+        )


### PR DESCRIPTION
<!--
Please replace _#ISSUE_ with just e.g. #12 if this PR resolves issue 12.
-->
## Resolves #266 

Raises `ValueError` with `num` < 3

***

## Checklist

* [ ] The changes include an associated explanation of how/why
* [ ] Test pass
* [ ] Documentation has been updated
* [ ] Changelog has been updated
