### PR TITLE
Raise exception if prune returns no conformers

### DIFF
--- a/autode/conformers/conformers.py
+++ b/autode/conformers/conformers.py
@@ -1,6 +1,7 @@
 import numpy as np
 from typing import Optional, Union
 from rdkit import Chem
+
 from autode.values import Distance, Energy
 from autode.atoms import Atom, Atoms
 from autode.config import Config
@@ -8,6 +9,7 @@ from autode.mol_graphs import make_graph, is_isomorphic
 from autode.geom import calc_heavy_atom_rmsd
 from autode.log import logger
 from autode.utils import ProcessPool
+from autode.exceptions import NoConformers
 
 
 def _calc_conformer(conformer, calc_type, method, keywords, n_cores=1):
@@ -242,9 +244,9 @@ class Conformers(list):
 
         n_conformers = len(self)
         if n_conformers == 0 and n_conformers != n_conformers_before_remove:
-            raise RuntimeError(
+            raise NoConformers(
                 f"Removed all the conformers "
-                f"{n_conformers_before_remove} -> {n_conformers}"
+                f"{n_conformers_before_remove} -> 0"
             )
 
     def _parallel_calc(self, calc_type, method, keywords):

--- a/autode/conformers/conformers.py
+++ b/autode/conformers/conformers.py
@@ -61,9 +61,7 @@ class Conformers(list):
         """
 
         if remove_no_energy:
-            for idx in reversed(range(len(self))):  # Enumerate backwards
-                if self[idx].energy is None:
-                    del self[idx]
+            self.remove_no_energy()
 
         self.prune_on_energy(e_tol=e_tol, n_sigma=n_sigma)
         self.prune_on_rmsd(rmsd_tol=rmsd_tol)
@@ -233,6 +231,21 @@ class Conformers(list):
 
         logger.info(f"Pruned on connectivity {n_prev_confs} -> {len(self)}")
         return None
+
+    def remove_no_energy(self) -> None:
+        """Remove all conformers from this list that do not have an energy"""
+        n_conformers_before_remove = len(self)
+
+        for idx in reversed(range(len(self))):  # Enumerate backwards
+            if self[idx].energy is None:
+                del self[idx]
+
+        n_conformers = len(self)
+        if n_conformers == 0 and n_conformers != n_conformers_before_remove:
+            raise RuntimeError(
+                f"Removed all the conformers "
+                f"{n_conformers_before_remove} -> {n_conformers}"
+            )
 
     def _parallel_calc(self, calc_type, method, keywords):
         """

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -177,11 +177,14 @@ def test_confs_energy_pruning3():
 
 def test_confs_no_energy_pruning():
     # Check that if energies are unassigned then conformers are removed
+    conf0 = Conformer(atoms=[Atom("H")])
+    conf1 = conf0.copy()
+    conf1.energy = -0.5
 
-    confs = Conformers([Conformer(atoms=[Atom("H")])])
+    confs = Conformers([conf0, conf1])
     confs.prune(remove_no_energy=True)
 
-    assert len(confs) == 0
+    assert len(confs) == 1
 
 
 def test_confs_rmsd_pruning1():

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -382,3 +382,21 @@ def test_conformer_coordinate_setting_with_different_atomic_attr():
     # But cannot set atoms with a different label (e.g. atomic symbol)
     with pytest.raises(ValueError):
         conf.atoms = Atoms([Atom("H")])
+
+
+def test_pruning_conformers_without_energy_raises():
+
+    conformers = Conformers(
+        [Conformer(atoms=[Atom("H")]), Conformer(atoms=[Atom("H")])]
+    )
+
+    assert sum(c.energy is None for c in conformers) == 2
+
+    with pytest.raises(Exception):
+        conformers.prune(remove_no_energy=True)
+
+
+def test_pruning_no_energy_with_no_conformers_is_possible():
+
+    conformers = Conformers()
+    conformers.remove_no_energy()

--- a/tests/test_conformers.py
+++ b/tests/test_conformers.py
@@ -2,6 +2,7 @@ from autode.atoms import Atom, Atoms
 from autode.species import Molecule, NCIComplex
 from autode.conformers import Conformer, Conformers
 from autode.conformers.conformers import _calc_conformer
+from autode.exceptions import NoConformers
 from autode.wrappers.ORCA import ORCA
 from autode.wrappers.XTB import XTB
 from autode.config import Config
@@ -395,7 +396,7 @@ def test_pruning_conformers_without_energy_raises():
 
     assert sum(c.energy is None for c in conformers) == 2
 
-    with pytest.raises(Exception):
+    with pytest.raises(NoConformers):
         conformers.prune(remove_no_energy=True)
 
 


### PR DESCRIPTION
Raises a more helpful exception in e.g #268 

### Questions

-  Is this behaviour intuitive? Certainly useful for debugging but are there circumstances where you'd want to call `prune` and allow an empty result?