### PR TITLE
Faster IDPP

### DIFF
--- a/autode/neb/original.py
+++ b/autode/neb/original.py
@@ -100,13 +100,20 @@ def total_energy(flat_coords, images, method, n_cores, plot_energies):
     )
 
     # Run an energy + gradient evaluation in parallel across all images
-    with ProcessPool(max_workers=n_cores) as pool:
-        results = [
-            pool.submit(energy_gradient, images[i], method, n_cores_pp)
+    if isinstance(method, Method):
+        with ProcessPool(max_workers=n_cores) as pool:
+            results = [
+                pool.submit(energy_gradient, images[i], method, n_cores_pp)
+                for i in range(1, len(images) - 1)
+            ]
+
+            images[1:-1] = [res.result() for res in results]
+    else:
+        # turn off parallelisation for IDPP
+        images[1:-1] = [
+            energy_gradient(images[i], method, n_cores_pp)
             for i in range(1, len(images) - 1)
         ]
-
-        images[1:-1] = [res.result() for res in results]
 
     images.increment()
 

--- a/autode/neb/original.py
+++ b/autode/neb/original.py
@@ -99,8 +99,13 @@ def total_energy(flat_coords, images, method, n_cores, plot_energies):
         f"{n_cores} total cores and {n_cores_pp} per process"
     )
 
-    # Run an energy + gradient evaluation in parallel across all images
-    if isinstance(method, Method):
+    # Run an energy + gradient evaluation across all images (parallel for EST)
+    if isinstance(method, IDPP):
+        images[1:-1] = [
+            energy_gradient(images[i], method, n_cores_pp)
+            for i in range(1, len(images) - 1)
+        ]
+    else:
         with ProcessPool(max_workers=n_cores) as pool:
             results = [
                 pool.submit(energy_gradient, images[i], method, n_cores_pp)
@@ -108,12 +113,6 @@ def total_energy(flat_coords, images, method, n_cores, plot_energies):
             ]
 
             images[1:-1] = [res.result() for res in results]
-    else:
-        # turn off parallelisation for IDPP
-        images[1:-1] = [
-            energy_gradient(images[i], method, n_cores_pp)
-            for i in range(1, len(images) - 1)
-        ]
 
     images.increment()
 


### PR DESCRIPTION
Remove parallelisation from IDPP. The overhead from creating new processes is larger than any gains from parallelisation.

Test for diels-alder with 200 IDPP images
 - MacOS - with parallelisation = 4.621 s, without parallelisation = 2.403 s
 - Windows - with parallelisation = 10.26 s, without parallelisation = 2.331 s

***

## Checklist

* [ ] The changes include an associated explanation of how/why
* [ ] Test pass
* [ ] Documentation has been updated
* [ ] Changelog has been updated
