### PR TITLE
Speedup package import time

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,4 @@ If **autodE** is used in a publication please consider citing the [paper](https:
 - Domen Pregeljc ([@dpregeljc](https://github.com/dpregeljc))
 - Jonathon Vandezande ([@jevandezande](https://github.com/jevandezande))
 - Shoubhik Maiti ([@shoubhikraj](https://github.com/shoubhikraj))
+- Daniel Hollas ([@danielhollas](https://github.com/danielhollas))

--- a/autode/neb/original.py
+++ b/autode/neb/original.py
@@ -3,7 +3,6 @@ The theory behind this original NEB implementation is taken from
 Henkelman and H. J ́onsson, J. Chem. Phys. 113, 9978 (2000)
 """
 import numpy as np
-import matplotlib.pyplot as plt
 
 from typing import Optional, Sequence, List, Any, TYPE_CHECKING, Union, Type
 from copy import deepcopy
@@ -361,6 +360,8 @@ class Images(Path):
         self, save=False, name="None", color=None, xlabel="NEB coordinate"
     ):
         """Plot the NEB surface"""
+        import matplotlib.pyplot as plt
+
         blues = plt.get_cmap("Blues")
 
         color = (
@@ -673,6 +674,8 @@ class NEB:
             etol_per_image: Energy tolerance per image to use in the L-BFGS-B
                             minimisation
         """
+        import matplotlib.pyplot as plt
+
         self.print_geometries(name=f"{name_prefix}neb_init")
 
         # Calculate energy on the first and final points as these will not be recalc-ed

--- a/autode/path/path.py
+++ b/autode/path/path.py
@@ -1,5 +1,4 @@
 import numpy as np
-import matplotlib.pyplot as plt
 
 from autode.species import Species
 from autode.input_output import atoms_to_xyz_file
@@ -147,6 +146,8 @@ class Path(list):
         self, save: bool, name: str, color: str, xlabel: str
     ) -> None:
         """Plot this path"""
+        import matplotlib.pyplot as plt
+
         if len(self) == 0 or any(item.energy is None for item in self):
             logger.error("Could not plot a surface, an energy was None")
             return

--- a/autode/pes/pes_nd.py
+++ b/autode/pes/pes_nd.py
@@ -5,7 +5,6 @@ surface and connecting minima and saddle points
 """
 import numpy as np
 import itertools as it
-import matplotlib.pyplot as plt
 
 from abc import ABC, abstractmethod
 from typing import (
@@ -196,6 +195,7 @@ class PESnD(ABC):
 
             units: Units of the surface. One of {'Ha', 'eV', 'kcal', 'kJ'}
         """
+        import matplotlib.pyplot as plt
 
         if interp_factor < 0:
             raise ValueError(
@@ -559,6 +559,8 @@ class PESnD(ABC):
             interp_factor:
             units_name:
         """
+        import matplotlib.pyplot as plt
+
         r_x = self._rs[0]
         energies, units = self._energies, energy_unit_from_name(units_name)
         energies = units.times * (energies - np.min(energies))
@@ -605,6 +607,7 @@ class PESnD(ABC):
             interp_factor:
             units_name:
         """
+        import matplotlib.pyplot as plt
         from mpl_toolkits.mplot3d import Axes3D
         from matplotlib.ticker import FormatStrFormatter
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -15,6 +15,9 @@ Bug Fixes
 *********
 - Fixes triangular rings being incorrectly treated as dihedral angles
 
+Usability improvements/Changes
+******************************
+- Faster import of autode package by lazily loading matplotlib
 
 1.4.1
 ------

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,32 @@
+"""Tests for the import speed of autode."""
+import sys
+
+import pytest
+
+SLOW_IMPORTS = ["matplotlib"]
+
+
+@pytest.fixture
+def unimport_slow_imports():
+    """Remove modules in ``SLOW_IMPORTS`` from ``sys.modules``."""
+    for module in SLOW_IMPORTS:
+        if module in sys.modules:
+            del sys.modules[module]
+
+
+@pytest.mark.usefixtures("unimport_slow_imports")
+def test_slow_imports_during_tab_completion():
+    """Check that importing autode does not import certain python modules that would make import slow."""
+
+    # Let's double check that the undesired imports are not already loaded
+    for modulename in SLOW_IMPORTS:
+        assert (
+            modulename not in sys.modules
+        ), f"Module `{modulename}` was not properly unloaded"
+
+    import autode
+
+    for modulename in SLOW_IMPORTS:
+        assert (
+            modulename not in sys.modules
+        ), f"Detected loaded module {modulename} after autode import"


### PR DESCRIPTION
We've been looking at the import time of the mlptrain package, which takes over a second on the cluster, and around 620ms on my dev machine with NVMe drive. Importing `autode` by itself takes 465 ms on main branch.

One of the easy wins is to import `matplotlib` only when needed, which saves around 160 ms.

Other potential improvements would come from delayed import of scipy and / or RDkit. But those would require more changes --- happy to open a separate PR if that is desired.

Corresponding PR on `mlptrain` repo: https://github.com/duartegroup/mlp-train/pull/84