### PR TITLE
Fix error in "atoms_to_xyz_file()" in "input_output.py"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ If **autodE** is used in a publication please consider citing the [paper](https:
 - Shoubhik Maiti ([@shoubhikraj](https://github.com/shoubhikraj))
 - Daniel Hollas ([@danielhollas](https://github.com/danielhollas))
 - Nils Heunemann ([@nilsheunemann](https://github.com/NilsHeunemann))
+- Sijie Fu ([@sijiefu](https://github.com/SijieFu))

--- a/autode/input_output.py
+++ b/autode/input_output.py
@@ -92,7 +92,7 @@ def atoms_to_xyz_file(
 
         for atom in atoms:
             x, y, z = atom.coord  # (Å)
-            print(f"{atom.label:<3}{x:10.5f}{y:10.5f}{z:10.5f}", file=xyz_file)
+            print(f"{atom.label:<3} {x:10.5f} {y:10.5f} {z:10.5f}", file=xyz_file)
     return None
 
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Functionality improvements
 Bug Fixes
 *********
 - Fixes no solvent being added in QRC calculations
+- Fixes cases where .xyz files are printed with no space between coordinates when the coordinate value is large.
 
 Usability improvements/Changes
 ******************************

--- a/tests/test_input_output.py
+++ b/tests/test_input_output.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 
 from autode.input_output import (
@@ -75,6 +77,14 @@ def test_making_xyz_file():
 
     xyz_lines = open("test.xyz", "r").readlines()
     assert len(xyz_lines) == 4
+
+    # Simulate situations when the coordinates are super large (or small)
+    atoms[0].coord = (sys.float_info.min, sys.float_info.max, -1e6)
+    atoms_to_xyz_file(atoms, filename="test.xyz", append=False)
+    
+    # check if the first atom is written correctly: the third line (index 2)
+    xyz_lines = open("test.xyz", "r").readlines()
+    assert len(xyz_lines[2].split()) == 4 and np.isclose(float(xyz_lines[2].split()[-1]), -1e6)
 
     # With append should add the next set of atoms to the same file
     atoms_to_xyz_file(atoms, filename="test.xyz", append=True)


### PR DESCRIPTION
Added explicit space to print xyz coordinates to account for occasional cases where there is no space printed between two numbers, for example, `H    13.56100 -35.93700-100.99000`, and thus the printed xyz file becomes invalid.

```
########################################################################

[ERROR] Program stopped due to fatal error
-2- reading geometry input 'test2_sp_xtb.xyz' failed
-1- Error: Could not parse coordinates from xyz file
  --> test2_sp_xtb.xyz:24:15-33
   |
24 | H    13.56100 -35.93700-100.99000
   |               ^^^^^^^^^^^^^^^^^^^ expected real value
   |
########################################################################
```

<!--
Please replace _#ISSUE_ with just e.g. #12 if this PR resolves issue 12.
## Resolves _#ISSUE_
-->


***

## Checklist

* [x] The changes include an associated explanation of how/why
* [x] Test pass
* [x] Documentation has been updated
* [x] Changelog has been updated
