### PR TITLE
fix projected frequencies

### DIFF
--- a/autode/hessians.py
+++ b/autode/hessians.py
@@ -15,6 +15,7 @@ from typing import (
     Union,
     TYPE_CHECKING,
 )
+
 from autode.wrappers.keywords import Functional, GradientKeywords
 from autode.log import logger
 from autode.config import Config
@@ -37,6 +38,8 @@ if TYPE_CHECKING:
     from autode.species.species import Species
     from autode.wrappers.keywords import GradientKeywords, Keywords
     from autode.values import Distance, Gradient
+
+THRESHOLD_ROTATION_FREQ = Frequency(50, "cm-1")
 
 
 class Hessian(ValueArray):
@@ -151,20 +154,9 @@ class Hessian(ValueArray):
         """
         n_atoms = len(self.atoms)
 
-        if n_atoms > 2:
-            # Get an orthonormal basis shifted from the principal rotation axis
-            _rot_M = np.array(
-                [
-                    [1.0, 0.0, 0.0],
-                    [0.0, 0.09983341664682815, -0.9950041652780258],
-                    [0.0, 0.9950041652780258, 0.09983341664682815],
-                ]
-            )
-
-            _, (e_x, e_y, e_z) = np.linalg.eigh(_rot_M.dot(self.atoms.moi))
-        else:
-            # Get a random orthonormal basis in 3D
-            (e_x, e_y, e_z), _ = np.linalg.qr(np.random.rand(3, 3))
+        e_x = np.array([1.0, 0.0, 0.0])
+        e_y = np.array([0.0, 1.0, 0.0])
+        e_z = np.array([0.0, 0.0, 1.0])
 
         t1 = np.tile(e_x, reps=n_atoms)
         t2 = np.tile(e_y, reps=n_atoms)
@@ -174,16 +166,16 @@ class Hessian(ValueArray):
         t4, t5, t6 = [], [], []
 
         for atom in self.atoms:
-            t4 += np.cross(e_x, atom.coord - com).tolist()
-            t5 += np.cross(e_y, atom.coord - com).tolist()
-            t6 += np.cross(e_z, atom.coord - com).tolist()
+            r = atom.coord - com
+            t4 += np.cross(e_x, r).tolist()
+            t5 += np.cross(e_y, r).tolist()
+            t6 += np.cross(e_z, r).tolist()
 
-        if any(np.isclose(np.linalg.norm(t_i), 0.0) for t_i in (t4, t5, t6)):
-            # Found linear dependency in rotation vectors, attempt to remove
-            # by initialising different random orthogonal vectors
-            return self._tr_vecs()
+        t4 = np.array(t4)
+        t5 = np.array(t5)
+        t6 = np.array(t6)
 
-        return t1, t2, t3, np.array(t4), np.array(t5), np.array(t6)
+        return t1, t2, t3, t4, t5, t6
 
     @cached_property
     def _proj_matrix(self) -> np.ndarray:
@@ -213,19 +205,21 @@ class Hessian(ValueArray):
 
         # Construct M^1/2, which as it's diagonal, is just the roots of the
         # diagonal elements
-        masses = np.repeat(
-            [atom.mass for atom in self.atoms], repeats=3, axis=np.newaxis
-        )
-        m_half = np.diag(np.sqrt(masses))
+        masses = np.repeat([atom.mass for atom in self.atoms], repeats=3)
+        m_half = np.sqrt(masses)
 
         for t_i in (t1, t2, t3, t4, t5, t6):
-            t_i[:] = np.dot(m_half, np.array(t_i))
-            t_i /= np.linalg.norm(t_i)
+            t_i *= m_half
 
         # Generate a transform matrix D with the first columns as translation/
         # rotation vectors with the remainder as random orthogonal columns
-        M = np.random.rand(3 * len(self.atoms), 3 * len(self.atoms)) - 0.5
-        M[:, :6] = np.column_stack((t1, t2, t3, t4, t5, t6))
+        M = np.eye(3 * len(self.atoms))
+
+        i = 0
+        for t_i in (t1, t2, t3, t4, t5, t6):
+            if not np.isclose(np.linalg.norm(t_i), 0):
+                M[:, i] = t_i
+                i += 1
 
         return np.linalg.qr(M)[0]
 
@@ -400,12 +394,41 @@ class Hessian(ValueArray):
                 "Could not calculate projected frequencies, must "
                 "have atoms set"
             )
-
         n_tr = self.n_tr  # Number of translational+rotational modes
-        lambdas = np.linalg.eigvalsh(self._proj_mass_weighted[n_tr:, n_tr:])
 
-        trans_rot_freqs = [Frequency(0.0) for _ in range(n_tr)]
+        H = self._proj_mass_weighted
+        norms = np.linalg.norm(H, axis=0)
+        max_norm = np.max(norms)
+        n_zeroed_modes = 0  # Number of modes that have been well projected out of the hessian
+        for norm in norms:
+            if norm / max_norm > 0.1 or n_zeroed_modes == n_tr:
+                break
+            else:
+                n_zeroed_modes += 1
+
+        if n_zeroed_modes != n_tr:
+            logger.warn(
+                f"Number of well zeroed eigenvectors of the hessian "
+                f"was [{n_zeroed_modes}] should be [{n_tr}]"
+            )
+
+        lambdas = np.linalg.eigvalsh(H[n_zeroed_modes:, n_zeroed_modes:])
+        trans_rot_freqs = [Frequency(0.0) for _ in range(n_zeroed_modes)]
         vib_freqs = self._eigenvalues_to_freqs(lambdas)
+
+        n_rotational_modes_in_vib_freqs = n_tr - n_zeroed_modes
+        for i in np.argsort(np.abs(np.array(vib_freqs))):
+            freq = vib_freqs[i]
+            if (
+                n_rotational_modes_in_vib_freqs > 0
+                and freq.real < THRESHOLD_ROTATION_FREQ
+            ):
+                logger.warning(
+                    "Found a vibrational mode that should be a rotation with "
+                    f"frequency [{freq}] cm-1. Forcing to zero"
+                )
+                vib_freqs[i] = Frequency(0.0)
+                n_rotational_modes_in_vib_freqs -= 1
 
         return trans_rot_freqs + vib_freqs
 
@@ -591,7 +614,7 @@ class NumericalHessianCalculator:
         return species.gradient.flatten()
 
     @property
-    def _init_gradient(self) -> "Gradient":
+    def _init_gradient(self) -> "np.ndarray":
         """Gradient at the initial geometry of the species"""
         return np.array(self._species.gradient).flatten()
 

--- a/autode/hessians.py
+++ b/autode/hessians.py
@@ -15,7 +15,6 @@ from typing import (
     Union,
     TYPE_CHECKING,
 )
-
 from autode.wrappers.keywords import Functional, GradientKeywords
 from autode.log import logger
 from autode.config import Config
@@ -171,11 +170,7 @@ class Hessian(ValueArray):
             t5 += np.cross(e_y, r).tolist()
             t6 += np.cross(e_z, r).tolist()
 
-        t4 = np.array(t4)
-        t5 = np.array(t5)
-        t6 = np.array(t6)
-
-        return t1, t2, t3, t4, t5, t6
+        return t1, t2, t3, np.array(t4), np.array(t5), np.array(t6)
 
     @cached_property
     def _proj_matrix(self) -> np.ndarray:

--- a/autode/wrappers/G09.py
+++ b/autode/wrappers/G09.py
@@ -546,9 +546,7 @@ class G09(autode.wrappers.methods.ExternalMethodOEGH):
         coords: List[List[float]] = []
 
         for i, line in enumerate(calc.output.file_lines):
-            if "Input orientation" in line or (
-                "Standard orientation" in line and len(coords) == 0
-            ):
+            if "Input orientation" in line or "Standard orientation" in line:
                 coords.clear()
                 xyz_lines = calc.output.file_lines[
                     i + 5 : i + 5 + calc.molecule.n_atoms

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,7 @@ Functionality improvements
 Bug Fixes
 *********
 - Fixes coordinate extraction in some G16 output files
+- Fixes the projected frequency calculation to make it rotation invariant by not discarding non-zeroed modes from the projected Hessian
 
 
 1.4.4

--- a/tests/test_wrappers/test_gaussian.py
+++ b/tests/test_wrappers/test_gaussian.py
@@ -204,13 +204,17 @@ def test_gauss_optts_calc():
     assert bond_added
 
     test_mol.calc_thermo(calc=calc, ss="1atm", lfm_method="igm")
-
     assert calc.terminated_normally
     assert calc.optimiser.converged
-    assert len(test_mol.imaginary_frequencies) == 1
+    assert test_mol.imaginary_frequencies is not None
 
-    assert -40.324 < test_mol.free_energy < -40.322
-    assert -40.301 < test_mol.enthalpy < -40.298
+    # NOTE: autodE does not remove eigenmodes that are not
+    # well zeroed from projected hessian. This is in contrast to
+    # other electronic structure codes
+    assert len(test_mol.imaginary_frequencies) == 2
+
+    assert -40.324 < test_mol.free_energy < -40.320
+    assert -40.300 < test_mol.enthalpy < -40.297
 
 
 def test_bad_gauss_output():


### PR DESCRIPTION
## Resolves #362 

Modifies the calculation of projected frequencies to not depend on the molecular orientation. 

This dependance arose because the previous implementation blindly followed the reference approach in which the projection is meant to create a block hessian matrix with structure
(0  0)
(0 H')
then discarding the first 5/6 rows that should be translations/rotations. However, if the rows were not ~0 then, depending on the chosen rotation vectors (which are coordinate dependent) https://github.com/duartegroup/autodE/blob/6a6eebe2b3c77c7a3f850b9e3c5cce32fafa7531/autode/hessians.py#L177-L179
then sometimes a vibrational mode could be discarded, leading to the wrong projected frequencies.

This PR
- Removes the random orientation of translational vectors as I don't think they're needed
- Checks the structure of the projected hessian before diagonalising a submatrix that has all the non-zero components
- Zeros not-quite zero modes that should be rotations (numerical issues?)

While debugging this I found that ORCA and Gaussian do something unexpected (to me at least). Their transform to normal modes is not a projection (i.e. eigenvalue preserving). For a distorted methane molecule
<img width="800" alt="ch4_distorted" src="https://github.com/user-attachments/assets/49c41e85-2908-46cf-84aa-0eb93aa07cbb">
you go from 2 strong imaginary frequencies unprojected (`Frequency(-881.98419 cm^-1), Frequency(-197.01737 cm^-1)`), to only one (`-178.5054 cm-1`). Plotting the energy along this mode 
<img width="200" alt="plot" src="https://github.com/user-attachments/assets/8a3f4766-de17-419e-a2db-bd8516416ded">
it's very much not a TS, so I am confused about what they're doing, and if it's ok

***

## Checklist

* [ ] The changes include an associated explanation of how/why
* [ ] Test pass
* [ ] Documentation has been updated
* [ ] Changelog has been updated
