### PR TITLE
pin libgfortran to 14 in CI

### DIFF
--- a/.github/scripts/install_xtb_ci.sh
+++ b/.github/scripts/install_xtb_ci.sh
@@ -7,5 +7,6 @@ if [[ "$OSTYPE" == "msys" ]]; then
   export XTBPATH=./xtb-6.5.1/share/xtb
   export PATH="./xtb-6.5.1/bin:$PATH"
 else
-  conda install xtb
+  # Pin libgfortran due to https://github.com/grimme-lab/xtb/issues/1277
+  conda install xtb libgfortran=14.*
 fi


### PR DESCRIPTION
Temporary fix for https://github.com/duartegroup/autodE/actions/runs/14955056856/job/42009591011 until there's an upstream xtb fix

***

## Checklist

* [x] The changes include an associated explanation of how/why
* [x] Test pass
* [x] Documentation has been updated
* n/a Changelog has been updated
