### PR TITLE
Updated Documentation for Molfunc

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,4 @@ If **autodE** is used in a publication please consider citing the [paper](https:
 - Nils Heunemann ([@nilsheunemann](https://github.com/NilsHeunemann))
 - Sijie Fu ([@sijiefu](https://github.com/SijieFu))
 - Javier Alfonso ([@javialra97](https://github.com/javialra97))
+- James Somper ([@JDSomper](https://github.com/JDSomper))

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,6 +20,7 @@ Usability improvements/Changes
 ******************************
 - Drops Python 3.8 support
 - Catches conformer calculation exceptions
+- Improves interfacing with solvent usage for ORCA 6.0
 
 1.4.4
 ------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -21,6 +21,7 @@ Usability improvements/Changes
 - Drops Python 3.8 support
 - Catches conformer calculation exceptions
 - Improves interfacing with solvent usage for ORCA 6.0
+- Updates Molfunc example to work with the most current version
 
 1.4.4
 ------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.4.6
+------
+-------
+
+Bug Fixes
+*********
+- Fixes Molfunc example to run with current version
+
 1.4.5
 ------
 -------
@@ -20,8 +28,6 @@ Usability improvements/Changes
 ******************************
 - Drops Python 3.8 support
 - Catches conformer calculation exceptions
-- Improves interfacing with solvent usage for ORCA 6.0
-- Updates Molfunc example to work with the most current version
 
 1.4.4
 ------

--- a/doc/common/methane_molfunc.py
+++ b/doc/common/methane_molfunc.py
@@ -1,11 +1,11 @@
 from molfunc import CoreMolecule, CombinedMolecule
 
 fragments = {
-    "NMe2": "CN([Fr])C",
-    "NH2": "N[Fr]",
-    "OH": "O[Fr]",
-    "Me": "C[Fr]",
-    "F": "F[Fr]",
+    "NMe2": "CN([*])C",
+    "NH2": "N[*]",
+    "OH": "O[*]",
+    "Me": "C[*]",
+    "F": "F[*]",
 }
 
 methane = CoreMolecule(xyz_filename="CH4.xyz", atoms_to_del=[2])


### PR DESCRIPTION
Changed code to version that works with most recent versions of molfunc + autode. [Fr] throws up errors, whilst [*] works well as intended.

## Checklist

* [ ] The changes include an associated explanation of how/why
* [ ] Test pass
* [ ] Documentation has been updated
* [ ] Changelog has been updated
