### PR TITLE
Rename autode logger from autode.log.log to autode

### DIFF
--- a/autode/log/log.py
+++ b/autode/log/log.py
@@ -77,7 +77,7 @@ else:
         level=get_log_level(),
         format="%(name)-12s: %(levelname)-8s %(message)s",
     )
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("autode")
 
 # Try and use colourful logs...
 try:


### PR DESCRIPTION
We've been trying to cleanup the logging output of mlptrain, and one tiny improvement was to rename the logger from the current `autode.log.log` to just `autode`, thus saving 8 characters per log line.

Here's a snippet of the current mlptrain log output to illustrate

<img width="1706" height="461" alt="image" src="https://github.com/user-attachments/assets/f44fc214-ec4b-4c5a-a6a5-6ef380885e1e" />


(this is a minor change, not sure if changelog entry is needed)

***

## Checklist

* [x] The changes include an associated explanation of how/why
* [ ] Test pass
* [ ] Documentation has been updated
* [ ] Changelog has been updated
